### PR TITLE
Define output data shape of importer and encapculate exceptions

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -175,10 +175,10 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:530d8bf8cc93a34019d08142593cf4d78a05c890da8cf87ffa3120af53772238",
-                "sha256:f78e99616b6f1a4745c0580e170251ef1bbafc0d0513e270c4bd281bf29d2800"
+                "sha256:1873c03321fc118f4e9746baf201ff990ceb915f433f23b395f5580d1840cb2a",
+                "sha256:9b6323ef4ab914af344ba97510e966d64ba91055d6b9afa6b30799340e89cc03"
             ],
-            "version": "==2.4.1"
+            "version": "==2.4.0"
         },
         "pytest": {
             "hashes": [

--- a/galaxy_importer/collection.py
+++ b/galaxy_importer/collection.py
@@ -40,11 +40,11 @@ def import_collection(filepath, logger=None):
     try:
         return _import_collection(filepath, logger)
     except Exception as exc:
-        collection = schema.ImportResult(
+        import_result = schema.ImportResult(
             result=RESULT_FAILED,
             error=str(exc),
         )
-        return json.dumps(attr.asdict(collection))
+        return json.dumps(attr.asdict(import_result))
 
 
 def _import_collection(filepath, logger):
@@ -74,15 +74,15 @@ class CollectionLoader(object):
         self._load_collection_manifest()
         self._check_filename_matches_manifest()
 
-        collection = schema.ImportResult(
-            collection_info=self.collection_info,
+        import_result = schema.ImportResult(
+            metadata=self.metadata,
             documentation=self.documentation,
             quality_score=self.quality_score,
             contents=self.contents,
             result=RESULT_COMPLETED,
             error=None,
         )
-        return json.dumps(attr.asdict(collection))
+        return json.dumps(attr.asdict(import_result))
 
     def _load_collection_manifest(self):
         manifest_file = os.path.join(self.path, 'MANIFEST.json')

--- a/galaxy_importer/collection.py
+++ b/galaxy_importer/collection.py
@@ -65,7 +65,7 @@ class CollectionLoader(object):
         self.path = path
         self.filename = filename
 
-        self.collection_info = None
+        self.metadata = None
         self.documentation = None
         self.quality_score = None
         self.contents = None
@@ -91,17 +91,17 @@ class CollectionLoader(object):
 
         with open(manifest_file, 'r') as f:
             try:
-                meta = schema.CollectionArtifactManifest.parse(f.read())
+                data = schema.CollectionArtifactManifest.parse(f.read())
             except ValueError as e:
                 raise exc.ManifestValidationError(str(e))
-            self.collection_info = meta.collection_info
+            self.metadata = data.collection_info
 
     def _check_filename_matches_manifest(self):
-        metadata = self.collection_info
         f = schema.CollectionFilename.parse(self.filename)
-        if f.namespace != metadata.namespace or f.name != metadata.name:
+        if (f.namespace != self.metadata.namespace or
+                f.name != self.metadata.name):
             raise exc.ManifestValidationError(
                 'Filename did not match metadata')
-        if f.version != semantic_version.Version(metadata.version):
+        if f.version != semantic_version.Version(self.metadata.version):
             raise exc.ManifestValidationError(
                 'Filename version did not match metadata')

--- a/galaxy_importer/schema.py
+++ b/galaxy_importer/schema.py
@@ -279,7 +279,7 @@ class CollectionArtifactManifest(object):
 class ImportResult(object):
     """Result of the import process, collection metadata, and contents."""
 
-    collection_info = attr.ib(default=None, type=GalaxyCollectionInfo)
+    metadata = attr.ib(default=None, type=GalaxyCollectionInfo)
     documentation = attr.ib(factory=dict)
     quality_score = attr.ib(default=None)
     contents = attr.ib(factory=list)

--- a/galaxy_importer/schema.py
+++ b/galaxy_importer/schema.py
@@ -273,3 +273,15 @@ class CollectionArtifactManifest(object):
         col_info = meta.pop('collection_info', None)
         meta['collection_info'] = GalaxyCollectionInfo(**col_info)
         return cls(**meta)
+
+
+@attr.s(frozen=True)
+class ImportResult(object):
+    """Result of the import process, collection metadata, and contents."""
+
+    collection_info = attr.ib(default=None, type=GalaxyCollectionInfo)
+    documentation = attr.ib(factory=dict)
+    quality_score = attr.ib(default=None)
+    contents = attr.ib(factory=list)
+    result = attr.ib(default=None)
+    error = attr.ib(default=None)


### PR DESCRIPTION
* Defines the shape of the json output of the galaxy-importer
* Adds key `documentation` for rendered collection documentation (collection-level and contents-level) in a layout to be determined in https://github.com/ansible/galaxy-dev/issues/37, and possibly stored in the CollectionVersion as a `documentation` json blob
* Encapsulates all exceptions into `error` key
    ```
    {
      "collection_info": null,
      "documentation": {},
      "quality_score": null,
      "contents": [],
      "result": "failed",
      "error": "Invalid collection metadata. Expecting 'license' to be a list of valid SPDX license identifiers, instead found invalid license identifiers: 'MITzzz' in 'license' value ['GPL-3.0-or-later', 'MITzzz']. For more info, visit https://spdx.org"
    }
    ```

Part of ansible/galaxy-dev#12
Signed-off-by: Andrew Crosby <acrosby@redhat.com>