### PR TITLE
Remove filename check from importer

### DIFF
--- a/galaxy_importer/collection.py
+++ b/galaxy_importer/collection.py
@@ -72,7 +72,9 @@ class CollectionLoader(object):
 
     def load(self):
         self._load_collection_manifest()
-        self._check_filename_matches_manifest()
+        # TODO: add filename check when worker can pass filename with
+        # collection details instead of filename made of hash string
+        # self._check_filename_matches_manifest()
 
         import_result = schema.ImportResult(
             metadata=self.metadata,

--- a/galaxy_importer/collection.py
+++ b/galaxy_importer/collection.py
@@ -22,7 +22,6 @@ import tarfile
 import tempfile
 
 import attr
-import semantic_version
 
 from . import exceptions as exc
 from . import schema
@@ -72,9 +71,8 @@ class CollectionLoader(object):
 
     def load(self):
         self._load_collection_manifest()
-        # TODO: add filename check when worker can pass filename with
+        # TODO(awcrosby): add filename check when worker can pass filename with
         # collection details instead of filename made of hash string
-        # self._check_filename_matches_manifest()
 
         import_result = schema.ImportResult(
             metadata=self.metadata,
@@ -97,13 +95,3 @@ class CollectionLoader(object):
             except ValueError as e:
                 raise exc.ManifestValidationError(str(e))
             self.metadata = data.collection_info
-
-    def _check_filename_matches_manifest(self):
-        f = schema.CollectionFilename.parse(self.filename)
-        if (f.namespace != self.metadata.namespace or
-                f.name != self.metadata.name):
-            raise exc.ManifestValidationError(
-                'Filename did not match metadata')
-        if f.version != semantic_version.Version(self.metadata.version):
-            raise exc.ManifestValidationError(
-                'Filename version did not match metadata')

--- a/tests/test_collection_loader.py
+++ b/tests/test_collection_loader.py
@@ -128,11 +128,11 @@ def test_manifest_fail(manifest_text, new_text, error_subset):
                 temp_dir, 'my_namespace-my_collection-2.0.2.tar.gz').load()
 
 
-def test_filename_not_match_manifest():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        with open(os.path.join(temp_dir, 'MANIFEST.json'), 'w') as fh:
-            fh.write(MANIFEST_JSON)
-
-        with pytest.raises(ManifestValidationError,
-                           match="Filename did not match metadata"):
-            CollectionLoader(temp_dir, 'ns-coll-1.2.3.tar.gz').load()
+# def test_filename_not_match_manifest():
+#     with tempfile.TemporaryDirectory() as temp_dir:
+#         with open(os.path.join(temp_dir, 'MANIFEST.json'), 'w') as fh:
+#             fh.write(MANIFEST_JSON)
+#
+#         with pytest.raises(ManifestValidationError,
+#                            match="Filename did not match metadata"):
+#             CollectionLoader(temp_dir, 'ns-coll-1.2.3.tar.gz').load()

--- a/tests/test_collection_loader.py
+++ b/tests/test_collection_loader.py
@@ -126,13 +126,3 @@ def test_manifest_fail(manifest_text, new_text, error_subset):
                            match=error_subset):
             CollectionLoader(
                 temp_dir, 'my_namespace-my_collection-2.0.2.tar.gz').load()
-
-
-# def test_filename_not_match_manifest():
-#     with tempfile.TemporaryDirectory() as temp_dir:
-#         with open(os.path.join(temp_dir, 'MANIFEST.json'), 'w') as fh:
-#             fh.write(MANIFEST_JSON)
-#
-#         with pytest.raises(ManifestValidationError,
-#                            match="Filename did not match metadata"):
-#             CollectionLoader(temp_dir, 'ns-coll-1.2.3.tar.gz').load()


### PR DESCRIPTION
Since pulp_ansible passes filename as a hash value instead of the name of the file uploaded (`[namespace].[name].[version].tar.gz`), this check cannot occur until edits are made to the pulp_ansible worker.