### PR TITLE
Remove handling and storing error details inside error and result keys

### DIFF
--- a/galaxy_importer/collection.py
+++ b/galaxy_importer/collection.py
@@ -38,14 +38,7 @@ RESULT_FAILED = 'failed'
 
 def import_collection(filepath, logger=None):
     logger = logger or default_logger
-    try:
-        return _import_collection(filepath, logger)
-    except Exception as exc:
-        import_result = schema.ImportResult(
-            result=RESULT_FAILED,
-            error=str(exc),
-        )
-        return attr.asdict(import_result)
+    return _import_collection(filepath, logger)
 
 
 def _import_collection(filepath, logger):
@@ -98,7 +91,6 @@ class CollectionLoader(object):
             docs_blob=self.docs_blob,
             contents=self.contents,
             result=RESULT_COMPLETED,
-            error=None,
         )
 
     def _load_collection_manifest(self):

--- a/galaxy_importer/collection.py
+++ b/galaxy_importer/collection.py
@@ -32,8 +32,6 @@ from galaxy_importer import schema
 default_logger = logging.getLogger(__name__)
 
 ALLOWED_TYPES = ['text/markdown', 'text/x-rst']
-RESULT_COMPLETED = 'completed'
-RESULT_FAILED = 'failed'
 
 
 def import_collection(filepath, logger=None):
@@ -90,7 +88,6 @@ class CollectionLoader(object):
             metadata=self.metadata,
             docs_blob=self.docs_blob,
             contents=self.contents,
-            result=RESULT_COMPLETED,
         )
 
     def _load_collection_manifest(self):

--- a/galaxy_importer/main.py
+++ b/galaxy_importer/main.py
@@ -31,6 +31,8 @@ def main(args=None):
     args = parse_args(args)
 
     data = call_importer(file=args.file)
+    if not data:
+        return
 
     if args.print_result:
         print(json.dumps(data, indent=4))
@@ -57,11 +59,13 @@ def call_importer(file):
 
     :param file: Artifact file to import.
     """
-    data = collection.import_collection(file)
-    if data['result'] == 'completed':
-        print('Importer processing completed successfully')
-    else:
-        print(f'Error during importer proccessing: {data["error"]}')
+    try:
+        data = collection.import_collection(file)
+    except Exception:
+        logging.error('Error during importer proccessing:', exc_info=True)
+        return None
+
+    logging.info('Importer processing completed successfully')
     return data
 
 

--- a/galaxy_importer/schema.py
+++ b/galaxy_importer/schema.py
@@ -254,7 +254,6 @@ class ImportResult(object):
     docs_blob = attr.ib(factory=dict)
     contents = attr.ib(factory=list, type=ResultContentItem)
     custom_license = attr.ib(default=None)
-    result = attr.ib(default=None)
 
 
 @attr.s(frozen=True)

--- a/galaxy_importer/schema.py
+++ b/galaxy_importer/schema.py
@@ -255,7 +255,6 @@ class ImportResult(object):
     contents = attr.ib(factory=list, type=ResultContentItem)
     custom_license = attr.ib(default=None)
     result = attr.ib(default=None)
-    error = attr.ib(default=None)
 
 
 @attr.s(frozen=True)

--- a/tests/test_collection_loader.py
+++ b/tests/test_collection_loader.py
@@ -85,7 +85,6 @@ def test_manifest_success():
         assert data.metadata.repository is None
         assert data.metadata.homepage is None
         assert data.metadata.issues is None
-        assert data.result == 'completed'
 
 
 @pytest.mark.parametrize(

--- a/tests/test_collection_loader.py
+++ b/tests/test_collection_loader.py
@@ -85,7 +85,6 @@ def test_manifest_success():
         assert data.metadata.repository is None
         assert data.metadata.homepage is None
         assert data.metadata.issues is None
-        assert data.error is None
         assert data.result == 'completed'
 
 

--- a/tests/test_galaxy_importer.py
+++ b/tests/test_galaxy_importer.py
@@ -17,12 +17,7 @@
 
 import pytest
 
-from galaxy_importer import __version__
 from galaxy_importer import main
-
-
-def test_version():
-    assert __version__ == '0.1.0'
 
 
 def test_parser():


### PR DESCRIPTION
This removes the `error` key from importer result and lets more detailed errors pass to caller.

The `result` key was also removed since it did not convey any extra information. The importer will complete successfully unless an error is raised - an error raised will be a failed import.