### PR TITLE
Change doc_strings key with ansible-doc output from list to dict

### DIFF
--- a/galaxy_importer/loaders.py
+++ b/galaxy_importer/loaders.py
@@ -110,14 +110,10 @@ class PluginLoader(ContentLoader):
             return None
 
         data = self._transform_options(data)
-
-        def _get_name_string(key):
-            return schema.DocString(
-                name=key,
-                string=data[self.name].get(key, None),
-            )
-
-        return [_get_name_string(key) for key in ANSIBLE_DOC_KEYS]
+        return {
+            key: data[self.name].get(key, None)
+            for key in ANSIBLE_DOC_KEYS
+        }
 
     def _transform_options(self, data):
         try:

--- a/galaxy_importer/schema.py
+++ b/galaxy_importer/schema.py
@@ -256,21 +256,13 @@ class ImportResult(object):
     custom_license = attr.ib(default=None)
 
 
-@attr.s(frozen=True)
-class DocString(object):
-    """Represents documentation blocks gathered from ansible-doc."""
-
-    name = attr.ib()
-    string = attr.ib()
-
-
 @attr.s
 class Content(object):
     """Represents content found in a collection."""
 
     name = attr.ib()
     content_type = attr.ib(type=constants.ContentType)
-    doc_strings = attr.ib(factory=list, type=DocString)
+    doc_strings = attr.ib(factory=dict)
     description = attr.ib(default=None)
     readme_file = attr.ib(default=None)
     readme_html = attr.ib(default=None)
@@ -279,10 +271,10 @@ class Content(object):
         """Set description if a plugin has doc_strings populated."""
         if not self.doc_strings:
             return
-        doc = list(
-            filter(lambda item: item.name == 'doc', self.doc_strings))[0]
-        if doc.string:
-            self.description = doc.string.get('short_description', None)
+        if not self.doc_strings.get('doc', None):
+            return
+        self.description = \
+            self.doc_strings['doc'].get('short_description', None)
 
 
 @attr.s(frozen=True)
@@ -297,7 +289,7 @@ class DocsBlobContentItem(object):
     """Documenation for piece of content, part of DocsBlob."""
     content_name = attr.ib()
     content_type = attr.ib()
-    doc_strings = attr.ib(factory=list, type=DocString)
+    doc_strings = attr.ib(factory=dict)
     readme_file = attr.ib(default=None)
     readme_html = attr.ib(default=None)
 

--- a/tests/test_collection_loader.py
+++ b/tests/test_collection_loader.py
@@ -163,14 +163,14 @@ def test_build_docs_blob_contents(get_readme_doc_file, get_html):
             {
                 'content_name': 'my_module',
                 'content_type': 'module',
-                'doc_strings': [],
+                'doc_strings': {},
                 'readme_file': None,
                 'readme_html': None,
             },
             {
                 'content_name': 'my_role',
                 'content_type': 'role',
-                'doc_strings': [],
+                'doc_strings': {},
                 'readme_file': None,
                 'readme_html': None,
             },

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -131,12 +131,10 @@ def test_get_doc_strings(mocked_run_ansible_doc, loader_module):
     mocked_run_ansible_doc.return_value = ANSIBLE_DOC_OUTPUT
     doc_strings = loader_module._get_doc_strings()
 
-    doc = list(filter(lambda item: item.name == 'doc', doc_strings))[0]
-    assert doc.string['version_added'] == '2.8'
-    assert doc.string['description'] == ['Sample module for testing.']
-
-    ret = list(filter(lambda item: item.name == 'return', doc_strings))[0]
-    assert ret.string is None
+    assert doc_strings['doc']['version_added'] == '2.8'
+    assert doc_strings['doc']['description'] == \
+        ['Sample module for testing.']
+    assert doc_strings['return'] is None
 
 
 def test_ansible_doc_unsupported_type():
@@ -178,8 +176,7 @@ def test_load(mocked_run_ansible_doc, loader_module):
     assert res.readme_file is None
     assert res.readme_html is None
     assert res.description == 'Sample module for testing'
-    doc = list(filter(lambda item: item.name == 'doc', res.doc_strings))[0]
-    assert doc.string['version_added'] == '2.8'
+    assert res.doc_strings['doc']['version_added'] == '2.8'
 
 
 @mock.patch.object(loaders.PluginLoader, '_run_ansible_doc')


### PR DESCRIPTION
Inside of `docs_blob` -> `contents`, the format of `doc_strings` is changed to:
```
"doc_strings": {
    "doc": {
        "filename": "/tmp/tmp5pu02fns/plugins/modules/yum.py",
        "module": "yum",
        ...
    },
    "metadata": {
        "status": [
            "stableinterface"
        ],
        "supported_by": "core"
    },
    ...
```
