### PR TITLE
Allow leading underscore in name of content

### DIFF
--- a/galaxy_importer/constants.py
+++ b/galaxy_importer/constants.py
@@ -21,6 +21,7 @@ import re
 
 MAX_TAGS_COUNT = 20
 NAME_REGEXP = re.compile(r'^(?!.*__)[a-z]+[0-9a-z_]*$')
+CONTENT_NAME_REGEXP = re.compile(r'^(?!.*__)[a-z_]+[0-9a-z_]*$')
 
 
 class ContentCategory(enum.Enum):

--- a/galaxy_importer/loaders.py
+++ b/galaxy_importer/loaders.py
@@ -71,7 +71,7 @@ class ContentLoader(metaclass=abc.ABCMeta):
         pass
 
     def _validate_name(self):
-        if not re.match(constants.NAME_REGEXP, self.name):
+        if not re.match(constants.CONTENT_NAME_REGEXP, self.name):
             raise exc.ContentNameError(
                 f'{self.content_type.value} name invalid format: {self.name}')
 


### PR DESCRIPTION
Allow content name to have leading underscore, since `_my_plugin` is a valid name