### PR TITLE
Don't fail import if dir inside plugin dir

### DIFF
--- a/galaxy_importer/finder.py
+++ b/galaxy_importer/finder.py
@@ -21,7 +21,6 @@ import logging
 import os
 
 from galaxy_importer import constants
-from galaxy_importer import exceptions as exc
 
 
 default_logger = logging.getLogger(__name__)
@@ -63,10 +62,6 @@ class ContentFinder(object):
     def _find_plugins(self, content_type, content_dir):
         for file_name in os.listdir(content_dir):
             file_path = os.path.join(content_dir, file_name)
-            if os.path.isdir(file_path):
-                raise exc.ContentFindError(
-                    f'Directory detected: "{os.path.basename(file_path)}". '
-                    'Nested plugins not supported.')
             if (not os.path.isfile(file_path)
                     or not file_name.endswith('.py')
                     or file_name == '__init__.py'):


### PR DESCRIPTION
This PR stops failing the import if a directory is found inside a plugin directory, it now skips the subdirectory. Support for processing content inside these subdirs is noted in https://github.com/ansible/galaxy-dev/issues/79