### PR TITLE
Check file paths and require licence or licence file

### DIFF
--- a/galaxy_importer/collection.py
+++ b/galaxy_importer/collection.py
@@ -77,6 +77,7 @@ class CollectionLoader(object):
     def load(self):
         self._load_collection_manifest()
         self._check_filename_matches_manifest()
+        self._check_metadata_filepaths()
         self.content_objs = list(self._load_contents())
 
         self.contents = self._build_contents_blob()
@@ -166,6 +167,16 @@ class CollectionLoader(object):
             documentation_files=rendered_doc_files,
             contents=contents,
         )
+
+    def _check_metadata_filepaths(self):
+        paths = []
+        paths.append(os.path.join(self.path, self.metadata.readme))
+        if self.metadata.license_file:
+            paths.append(os.path.join(self.path, self.metadata.license_file))
+        for path in paths:
+            if not os.path.exists(path):
+                raise exc.ManifestValidationError(
+                    f'Could not find file {os.path.basename(path)}')
 
 
 def _run_post_load_plugins(artifact_file, metadata, content_objs, logger=None):

--- a/galaxy_importer/schema.py
+++ b/galaxy_importer/schema.py
@@ -91,9 +91,7 @@ class CollectionInfo(object):
     authors = attr.ib(factory=list)
     tags = attr.ib(factory=list)
 
-    license_file = attr.ib(
-        default=None,
-        validator=attr.validators.optional(attr.validators.instance_of(str)))
+    license_file = attr.ib(default=None)
     readme = attr.ib(default=None)
 
     dependencies = attr.ib(
@@ -204,6 +202,7 @@ class CollectionInfo(object):
     @documentation.validator
     @homepage.validator
     @issues.validator
+    @license_file.validator
     def _check_non_null_str(self, attribute, value):
         """Check that if value is present, it must be a string."""
         if value is not None and not isinstance(value, str):
@@ -211,16 +210,21 @@ class CollectionInfo(object):
 
     def __attrs_post_init__(self):
         """Checks called post init validation."""
-        self._check_license_or_license_file(self.license, self.license_file)
+        self._check_license_or_license_file()
 
-    def _check_license_or_license_file(self, license_ids, license_file):
-        """Confirm presence of either license or license_file."""
-        if license_ids or license_file:
+    def _check_license_or_license_file(self):
+        """Confirm mutually exclusive presence of license or license_file."""
+        if bool(self.license) != bool(self.license_file):
             return
+
+        if self.license and self.license_file:
+            self.value_error(
+                "The 'license' and 'license_file' keys are mutually exclusive")
+
         self.value_error(
             "Valid values for 'license' or 'license_file' are required. "
-            f"But 'license' ({license_ids}) and "
-            f"'license_file' ({license_file}) were invalid.")
+            f"But 'license' ({self.license}) and "
+            f"'license_file' ({self.license_file}) were invalid.")
 
 
 @attr.s(frozen=True)

--- a/tests/test_collection_info.py
+++ b/tests/test_collection_info.py
@@ -178,6 +178,21 @@ def test_invalid_semver(collection_info, invalid_semver):
         CollectionInfo(**collection_info)
 
 
+def test_license(collection_info):
+    collection_info['license'] = ['MIT', 'GPL-2.0-only', 'Apache-2.0']
+    res = CollectionInfo(**collection_info)
+    assert res.license == ['MIT', 'GPL-2.0-only', 'Apache-2.0']
+    assert res.license_file is None
+
+    collection_info['license'] = ['MIT', 'not-a-real-license', 'n00p']
+    with pytest.raises(ValueError, match=r"Expecting 'license' to be a list of valid SPDX"):
+        CollectionInfo(**collection_info)
+
+    collection_info['license'] = 'MIT'
+    with pytest.raises(ValueError, match=r"'license' to be a list of strings"):
+        CollectionInfo(**collection_info)
+
+
 def test_license_file(collection_info):
     collection_info['license'] = []
     collection_info['license_file'] = 'my_very_own_license.txt'
@@ -185,17 +200,23 @@ def test_license_file(collection_info):
     assert len(res.license) == 0
     assert res.license_file == 'my_very_own_license.txt'
 
-
-def test_empty_lic_and_lic_file(collection_info):
-    collection_info['license'] = []
-    with pytest.raises(ValueError,
-                       match=r"'license' or 'license_file' are required"):
+    collection_info['license_file'] = ['my_very_own_license.txt']
+    with pytest.raises(ValueError, match=r"'license_file' must be a string"):
         CollectionInfo(**collection_info)
 
 
-def test_license_not_list_of_str(collection_info):
-    collection_info['license'] = 'MIT'
-    with pytest.raises(ValueError, match=r"'license' to be a list of strings"):
+def test_empty_lic_and_lic_file(collection_info):
+    collection_info['license'] = []
+    with pytest.raises(ValueError, match=r"'license' or 'license_file' are required"):
+        CollectionInfo(**collection_info)
+
+
+def test_both_lic_and_lic_file(collection_info):
+    collection_info['license_file'] = 'my_very_own_license.txt'
+    with pytest.raises(
+        ValueError,
+        match=r"'license' and 'license_file' keys are mutually exclusive"
+    ):
         CollectionInfo(**collection_info)
 
 


### PR DESCRIPTION
* Check that `readme` file exists
* Check that `license_file` exists if it is populated
* Confirm mutually exclusive presence of `license` or `license_file`