### PR TITLE
Support nested tables in doc and return docstrings

### DIFF
--- a/galaxy_importer/loaders.py
+++ b/galaxy_importer/loaders.py
@@ -111,27 +111,29 @@ class PluginLoader(ContentLoader):
             self.log.error(f'No "{self.name}" key in ansible-doc output')
             return None
 
-        data = self._transform_params(data)
+        data = self._transform_doc_strings(data)
         return {
             key: data[self.name].get(key, None)
             for key in ANSIBLE_DOC_KEYS
         }
 
-    def _transform_params(self, data):
-        def transform(dict_of_dict):
+    def _transform_doc_strings(self, data):
+        """Transform data meant for UI tables into format suitable for UI."""
+
+        def dict_to_named_list(dict_of_dict):
+            """Return new list of dicts for given dict of dicts."""
             return [
                 {'name': key, **deepcopy(dict_of_dict[key])} for
                 key in dict_of_dict.keys()
             ]
 
         doc = data[self.name]['doc']
-        if doc and 'options' in doc.keys() and \
-                isinstance(doc['options'], dict):
-            doc['options'] = transform(doc['options'])
+        if doc and 'options' in doc.keys() and isinstance(doc['options'], dict):
+            doc['options'] = dict_to_named_list(doc['options'])
 
         ret = data[self.name]['return']
         if ret and isinstance(ret, dict):
-            data[self.name]['return'] = transform(ret)
+            data[self.name]['return'] = dict_to_named_list(ret)
 
         return data
 

--- a/galaxy_importer/loaders.py
+++ b/galaxy_importer/loaders.py
@@ -127,13 +127,24 @@ class PluginLoader(ContentLoader):
                 key in dict_of_dict.keys()
             ]
 
-        doc = data[self.name]['doc']
+        def handle_nested_tables(obj, table_key):
+            """Recurse over dict to replace nested tables with updated format."""
+            if table_key in obj.keys() and isinstance(obj[table_key], dict):
+                obj[table_key] = dict_to_named_list(obj[table_key])
+                for row in obj[table_key]:
+                    handle_nested_tables(row, table_key)
+
+        doc = data[self.name].get('doc')
         if doc and 'options' in doc.keys() and isinstance(doc['options'], dict):
             doc['options'] = dict_to_named_list(doc['options'])
+            for d in doc['options']:
+                handle_nested_tables(d, table_key='suboptions')
 
-        ret = data[self.name]['return']
+        ret = data[self.name].get('return')
         if ret and isinstance(ret, dict):
             data[self.name]['return'] = dict_to_named_list(ret)
+            for d in data[self.name]['return']:
+                handle_nested_tables(d, table_key='contains')
 
         return data
 

--- a/tests/test_loader_doc_strings.py
+++ b/tests/test_loader_doc_strings.py
@@ -1,0 +1,237 @@
+# (c) 2012-2019, Ansible by Red Hat
+#
+# This file is part of Ansible Galaxy
+#
+# Ansible Galaxy is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by
+# the Apache Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Ansible Galaxy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License
+# along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
+
+import json
+import pytest
+
+from galaxy_importer import constants
+from galaxy_importer import loaders
+
+
+@pytest.fixture
+def loader_module():
+    return loaders.PluginLoader(
+        content_type=constants.ContentType.MODULE,
+        rel_path='plugins/modules/my_sample_module.py',
+        root='/tmp/tmpiskt5e2n')
+
+
+def test_doc_options(loader_module):
+    ansible_doc_output = """
+        {
+            "my_sample_module": {
+                "doc": {
+                    "description": ["Sample module for testing."],
+                    "short_description": "Sample module for testing",
+                    "version_added": "2.8",
+                    "options": {
+                        "exclude": {
+                            "description": ["This is the message to send..."],
+                            "required": "true"
+                        },
+                        "use_new": {
+                            "description": ["Control is passed..."],
+                            "version_added": "2.7",
+                            "default": "auto"
+                        }
+                    }
+                }
+            }
+        }
+    """
+    data = json.loads(ansible_doc_output)
+    transformed_data = loader_module._transform_doc_strings(data)
+    assert transformed_data['my_sample_module']['doc']['options'] == [
+        {
+            'name': 'exclude',
+            'description': ['This is the message to send...'],
+            'required': 'true',
+        },
+        {
+            'name': 'use_new',
+            'description': ['Control is passed...'],
+            'version_added': '2.7',
+            'default': 'auto'
+        }
+    ]
+
+
+def test_doc_nested_suboptions(loader_module):
+    ansible_doc_output = """
+        {
+            "my_sample_module": {
+                "doc": {
+                    "description": ["Sample module for testing."],
+                    "short_description": "Sample module for testing",
+                    "version_added": "2.8",
+                    "options": {
+                        "exclude": {
+                            "description": ["This is the message to send..."],
+                            "required": "true"
+                        },
+                        "lan2_port_setting": {
+                            "description": ["Control is passed..."],
+                            "suboptions": {
+                                "enabled": {
+                                    "description": ["If set to True..."],
+                                    "type": "bool"
+                                },
+                                "network_setting": {
+                                    "description": ["If the enable field..."],
+                                    "suboptions": {
+                                        "address": {
+                                            "description": ["The IPv4 Address of LAN2"]
+                                        },
+                                        "gateway": {
+                                            "description": ["The default gateway of LAN2"]
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    """
+    data = json.loads(ansible_doc_output)
+    transformed_data = loader_module._transform_doc_strings(data)
+    assert transformed_data['my_sample_module']['doc']['options'] == [
+        {
+            'name': 'exclude',
+            'description': ['This is the message to send...'],
+            'required': 'true',
+        },
+        {
+            'name': 'lan2_port_setting',
+            'description': ['Control is passed...'],
+            'suboptions': [
+                {
+                    'name': 'enabled',
+                    'description': ['If set to True...'],
+                    'type': 'bool',
+                },
+                {
+                    'name': 'network_setting',
+                    'description': ['If the enable field...'],
+                    'suboptions': [
+                        {
+                            'name': 'address',
+                            'description': ['The IPv4 Address of LAN2'],
+                        },
+                        {
+                            'name': 'gateway',
+                            'description': ['The default gateway of LAN2'],
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+
+
+def test_return(loader_module):
+    ansible_doc_output = """
+        {
+            "my_sample_module": {
+                "return": {
+                    "message": {
+                        "description": ["The output message the sample module generates"]
+                    },
+                    "original_message": {
+                        "description": ["The original name param that was passed in"],
+                        "type": "str"
+                    }
+                }
+            }
+        }
+    """
+
+    data = json.loads(ansible_doc_output)
+    transformed_data = loader_module._transform_doc_strings(data)
+    assert transformed_data['my_sample_module']['return'] == [
+        {
+            'name': 'message',
+            'description': ['The output message the sample module generates']
+        },
+        {
+            'name': 'original_message',
+            'description': ['The original name param that was passed in'],
+            'type': 'str'
+        }
+    ]
+
+
+def test_return_nested_contains(loader_module):
+    ansible_doc_output = """
+        {
+            "my_sample_module": {
+                "return": {
+                    "resources": {
+                        "contains": {
+                            "acceleratorType": {
+                                "description": ["The type of..."],
+                                "returned": "success"
+                            },
+                            "networkEndpoints": {
+                                "contains": {
+                                    "ipAddress": {
+                                        "description": ["The IP address."],
+                                        "type": "str"
+                                    },
+                                    "port": {
+                                        "description": ["The port"],
+                                        "type": "int"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    """
+
+    data = json.loads(ansible_doc_output)
+    transformed_data = loader_module._transform_doc_strings(data)
+    assert transformed_data['my_sample_module']['return'] == [
+        {
+            'name': 'resources',
+            'contains': [
+                {
+                    'name': 'acceleratorType',
+                    'description': ['The type of...'],
+                    'returned': 'success',
+                },
+                {
+                    'name': 'networkEndpoints',
+                    'contains': [
+                        {
+                            'name': 'ipAddress',
+                            'description': ['The IP address.'],
+                            'type': 'str',
+                        },
+                        {
+                            'name': 'port',
+                            'description': ['The port'],
+                            'type': 'int',
+                        },
+                    ]
+                }
+            ]
+        },
+    ]

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -16,7 +16,6 @@
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
 import attr
-import json
 import os
 import pytest
 import re
@@ -160,35 +159,6 @@ def test_ansible_doc_unsupported_type():
     assert constants.ContentType.ACTION_PLUGIN.value not in \
         loaders.ANSIBLE_DOC_SUPPORTED_TYPES
     assert not loader_action._get_doc_strings()
-
-
-def test_ansible_doc_rams(loader_module):
-    data = json.loads(ANSIBLE_DOC_OUTPUT)
-    transformed_data = loader_module._transform_doc_strings(data)
-    assert transformed_data['my_sample_module']['doc']['options'] == [
-        {
-            'name': 'exclude',
-            'description': ['This is the message to send...'],
-            'required': 'true',
-        },
-        {
-            'name': 'use_new',
-            'description': ['Control is passed...'],
-            'version_added': '2.7',
-            'default': 'auto'
-        }
-    ]
-    assert transformed_data['my_sample_module']['return'] == [
-        {
-            'name': 'message',
-            'description': 'The output message the sample module generates'
-        },
-        {
-            'name': 'original_message',
-            'description': 'The original name param that was passed in',
-            'type': 'str'
-        }
-    ]
 
 
 @mock.patch.object(loaders.PluginLoader, '_run_ansible_doc')

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -162,9 +162,9 @@ def test_ansible_doc_unsupported_type():
     assert not loader_action._get_doc_strings()
 
 
-def test_ansible_doc_transform_params(loader_module):
+def test_ansible_doc_rams(loader_module):
     data = json.loads(ANSIBLE_DOC_OUTPUT)
-    transformed_data = loader_module._transform_params(data)
+    transformed_data = loader_module._transform_doc_strings(data)
     assert transformed_data['my_sample_module']['doc']['options'] == [
         {
             'name': 'exclude',


### PR DESCRIPTION
This includes `suboptions` inside `doc`, and `contains` inside `return`

Resolves: https://github.com/ansible/galaxy-dev/issues/120