### PR TITLE
Support doc_fragments in docs_blob output

### DIFF
--- a/galaxy_importer/loaders.py
+++ b/galaxy_importer/loaders.py
@@ -152,13 +152,15 @@ class DocStringLoader():
         json_output = self._run_ansible_doc()
 
         if not json_output:
-            return
+            return None
 
         data = json.loads(json_output)
         if not isinstance(data, dict):
-            raise exc.ImporterError('ansible-doc output not dictionary as expected')
+            self.log.error('ansible-doc output not dictionary as expected')
+            return None
         if len(data.keys()) != 1:
-            raise exc.ImporterError('ansible-doc output did not return single top-level key')
+            self.log.error('ansible-doc output did not return single top-level key')
+            return None
         data = list(data.values())[0]
         data = self._transform_doc_strings(data)
 

--- a/galaxy_importer/loaders.py
+++ b/galaxy_importer/loaders.py
@@ -193,7 +193,7 @@ class PluginLoader(ContentLoader):
             '--json',
         ]
         self.log.debug('CMD: {}'.format(' '.join(cmd)))
-        proc = Popen(' '.join(cmd), cwd=self.root, stdout=PIPE, stderr=PIPE, shell=True)
+        proc = Popen(cmd, cwd=self.root, stdout=PIPE, stderr=PIPE)
         stdout, stderr = proc.communicate()
         if proc.returncode:
             self.log.error(f'Error running ansible-doc: {stderr}')

--- a/galaxy_importer/loaders.py
+++ b/galaxy_importer/loaders.py
@@ -186,13 +186,14 @@ class PluginLoader(ContentLoader):
 
     def _run_ansible_doc(self):
         cmd = [
+            'env', f'ANSIBLE_COLLECTIONS_PATHS={self.tmp_dir}',
             'ansible-doc',
+            self.fq_name,
             '--type', self.content_type.value,
-            '-M', os.path.dirname(self.rel_path),
-            self.name,
-            '--json']
+            '--json',
+        ]
         self.log.debug('CMD: {}'.format(' '.join(cmd)))
-        proc = Popen(cmd, cwd=self.root, stdout=PIPE, stderr=PIPE)
+        proc = Popen(' '.join(cmd), cwd=self.root, stdout=PIPE, stderr=PIPE, shell=True)
         stdout, stderr = proc.communicate()
         if proc.returncode:
             self.log.error(f'Error running ansible-doc: {stderr}')

--- a/galaxy_importer/loaders.py
+++ b/galaxy_importer/loaders.py
@@ -201,8 +201,8 @@ class DocStringLoader():
                 for row in obj[table_key]:
                     handle_nested_tables(row, table_key)
 
-        doc = data.get('doc', None)
-        if doc and 'options' in doc.keys() and isinstance(doc['options'], dict):
+        doc = data.get('doc', {})
+        if isinstance(doc.get('options'), dict):
             doc['options'] = dict_to_named_list(doc['options'])
             for d in doc['options']:
                 handle_nested_tables(d, table_key='suboptions')

--- a/galaxy_importer/loaders.py
+++ b/galaxy_importer/loaders.py
@@ -179,7 +179,7 @@ class DocStringLoader():
         proc = Popen(cmd, cwd=self.path, stdout=PIPE, stderr=PIPE)
         stdout, stderr = proc.communicate()
         if proc.returncode:
-            self.log.error(f'Error running ansible-doc: {stderr}')
+            self.log.error(f'Error running ansible-doc: returncode={proc.returncode} {stderr}')
             return None
         return stdout
 

--- a/tests/test_loader_doc_strings.py
+++ b/tests/test_loader_doc_strings.py
@@ -20,7 +20,6 @@ import pytest
 from unittest import mock
 
 from galaxy_importer import constants
-from galaxy_importer import exceptions as exc
 from galaxy_importer import loaders
 
 
@@ -111,13 +110,13 @@ def test_get_doc_strings(mocked_run_ansible_doc, doc_string_loader):
     assert doc_strings['doc']['description'] == \
         ['Sample module for testing.']
 
-    with pytest.raises(exc.ImporterError, match="did not return single top-level key"):
-        mocked_run_ansible_doc.return_value = '{}'
-        doc_string_loader.load()
+    mocked_run_ansible_doc.return_value = '{}'
+    doc_strings = doc_string_loader.load()
+    assert not doc_strings
 
-    with pytest.raises(exc.ImporterError, match="ansible-doc output not dictionary as expected"):
-        mocked_run_ansible_doc.return_value = '[]'
-        doc_string_loader.load()
+    mocked_run_ansible_doc.return_value = '[]'
+    doc_strings = doc_string_loader.load()
+    assert not doc_strings
 
 
 def test_return(doc_string_loader):

--- a/tests/test_loader_doc_strings.py
+++ b/tests/test_loader_doc_strings.py
@@ -54,8 +54,9 @@ def test_doc_options(loader_module):
         }
     """
     data = json.loads(ansible_doc_output)
+    data = list(data.values())[0]
     transformed_data = loader_module._transform_doc_strings(data)
-    assert transformed_data['my_sample_module']['doc']['options'] == [
+    assert transformed_data['doc']['options'] == [
         {
             'name': 'exclude',
             'description': ['This is the message to send...'],
@@ -109,8 +110,9 @@ def test_doc_nested_suboptions(loader_module):
         }
     """
     data = json.loads(ansible_doc_output)
+    data = list(data.values())[0]
     transformed_data = loader_module._transform_doc_strings(data)
-    assert transformed_data['my_sample_module']['doc']['options'] == [
+    assert transformed_data['doc']['options'] == [
         {
             'name': 'exclude',
             'description': ['This is the message to send...'],
@@ -162,8 +164,9 @@ def test_return(loader_module):
     """
 
     data = json.loads(ansible_doc_output)
+    data = list(data.values())[0]
     transformed_data = loader_module._transform_doc_strings(data)
-    assert transformed_data['my_sample_module']['return'] == [
+    assert transformed_data['return'] == [
         {
             'name': 'message',
             'description': ['The output message the sample module generates']
@@ -207,8 +210,9 @@ def test_return_nested_contains(loader_module):
     """
 
     data = json.loads(ansible_doc_output)
+    data = list(data.values())[0]
     transformed_data = loader_module._transform_doc_strings(data)
-    assert transformed_data['my_sample_module']['return'] == [
+    assert transformed_data['return'] == [
         {
             'name': 'resources',
             'contains': [

--- a/tests/test_loader_doc_strings.py
+++ b/tests/test_loader_doc_strings.py
@@ -17,20 +17,143 @@
 
 import json
 import pytest
+from unittest import mock
 
 from galaxy_importer import constants
+from galaxy_importer import exceptions as exc
 from galaxy_importer import loaders
 
 
+ANSIBLE_DOC_OUTPUT = """
+    {"my_sample_module": {
+        "doc": {
+            "description": ["Sample module for testing."],
+            "short_description": "Sample module for testing",
+            "version_added": "2.8",
+            "options": {
+                "exclude": {
+                    "description": ["This is the message to send..."],
+                    "required": "true"
+                },
+                "use_new": {
+                    "description": ["Control is passed..."],
+                    "version_added": "2.7",
+                    "default": "auto"
+                }
+            }
+        },
+        "examples": null,
+        "metadata": null,
+        "return": {
+            "message": {
+                "description": "The output message the sample module generates"
+            },
+            "original_message": {
+                "description": "The original name param that was passed in",
+                "type": "str"
+            }
+        }
+    }}
+"""
+
+
 @pytest.fixture
-def loader_module():
-    return loaders.PluginLoader(
-        content_type=constants.ContentType.MODULE,
-        rel_path='plugins/modules/my_sample_module.py',
-        root='/tmp/tmpiskt5e2n')
+def doc_string_loader():
+    return loaders.DocStringLoader(
+        content_type=constants.ContentType.MODULE.value,
+        path=None,
+        fq_name='my_namespace.my_collection.my_sample_module')
 
 
-def test_doc_options(loader_module):
+def test_init_loader(doc_string_loader):
+    assert doc_string_loader.content_type == 'module'
+    assert doc_string_loader.fq_name == 'my_namespace.my_collection.my_sample_module'
+
+
+@mock.patch('galaxy_importer.loaders.Popen')
+def test_run_ansible_doc(mocked_popen, doc_string_loader):
+    mocked_popen.return_value.communicate.return_value = (
+        'expected output', '')
+    mocked_popen.return_value.returncode = 0
+    res = doc_string_loader._run_ansible_doc()
+    assert res == 'expected output'
+
+
+@mock.patch('galaxy_importer.loaders.Popen')
+def test_run_ansible_doc_exception(mocked_popen, doc_string_loader):
+    mocked_popen.return_value.communicate.return_value = (
+        'output', 'error that causes exception')
+    mocked_popen.return_value.returncode = 1
+    res = doc_string_loader._run_ansible_doc()
+    assert not res
+
+
+def test_ansible_doc_unsupported_type():
+    action_plugin_loader = loaders.DocStringLoader(
+        content_type=constants.ContentType.ACTION_PLUGIN.value,
+        path=None,
+        fq_name='my_namespace.my_collection.my_sample_module')
+    assert constants.ContentType.ACTION_PLUGIN.value not in loaders.ANSIBLE_DOC_SUPPORTED_TYPES
+    assert not action_plugin_loader.load()
+
+
+@mock.patch.object(loaders.DocStringLoader, '_run_ansible_doc')
+def test_ansible_doc_no_output(mocked_run_ansible_doc, doc_string_loader):
+    mocked_run_ansible_doc.return_value = ''
+    assert doc_string_loader.load() is None
+
+
+@mock.patch.object(loaders.DocStringLoader, '_run_ansible_doc')
+def test_get_doc_strings(mocked_run_ansible_doc, doc_string_loader):
+    mocked_run_ansible_doc.return_value = ANSIBLE_DOC_OUTPUT
+    doc_strings = doc_string_loader.load()
+    assert doc_strings['doc']['version_added'] == '2.8'
+    assert doc_strings['doc']['description'] == \
+        ['Sample module for testing.']
+
+    with pytest.raises(exc.ImporterError, match="did not return single top-level key"):
+        mocked_run_ansible_doc.return_value = '{}'
+        doc_string_loader.load()
+
+    with pytest.raises(exc.ImporterError, match="ansible-doc output not dictionary as expected"):
+        mocked_run_ansible_doc.return_value = '[]'
+        doc_string_loader.load()
+
+
+def test_return(doc_string_loader):
+    ansible_doc_output = """
+        {
+            "my_sample_module": {
+                "return": {
+                    "message": {
+                        "description": ["The output message the sample module generates"]
+                    },
+                    "original_message": {
+                        "description": ["The original name param that was passed in"],
+                        "type": "str"
+                    }
+                }
+            }
+        }
+    """
+
+    data = json.loads(ansible_doc_output)
+    data = list(data.values())[0]
+    transformed_data = doc_string_loader._transform_doc_strings(data)
+    assert transformed_data['return'] == [
+        {
+            'name': 'message',
+            'description': ['The output message the sample module generates']
+        },
+        {
+            'name': 'original_message',
+            'description': ['The original name param that was passed in'],
+            'type': 'str'
+        }
+    ]
+
+
+def test_doc_options(doc_string_loader):
     ansible_doc_output = """
         {
             "my_sample_module": {
@@ -55,7 +178,7 @@ def test_doc_options(loader_module):
     """
     data = json.loads(ansible_doc_output)
     data = list(data.values())[0]
-    transformed_data = loader_module._transform_doc_strings(data)
+    transformed_data = doc_string_loader._transform_doc_strings(data)
     assert transformed_data['doc']['options'] == [
         {
             'name': 'exclude',
@@ -71,7 +194,69 @@ def test_doc_options(loader_module):
     ]
 
 
-def test_doc_nested_suboptions(loader_module):
+def test_return_nested_contains(doc_string_loader):
+    ansible_doc_output = """
+        {
+            "my_sample_module": {
+                "return": {
+                    "resources": {
+                        "contains": {
+                            "acceleratorType": {
+                                "description": ["The type of..."],
+                                "returned": "success"
+                            },
+                            "networkEndpoints": {
+                                "contains": {
+                                    "ipAddress": {
+                                        "description": ["The IP address."],
+                                        "type": "str"
+                                    },
+                                    "port": {
+                                        "description": ["The port"],
+                                        "type": "int"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    """
+
+    data = json.loads(ansible_doc_output)
+    data = list(data.values())[0]
+    transformed_data = doc_string_loader._transform_doc_strings(data)
+    assert transformed_data['return'] == [
+        {
+            'name': 'resources',
+            'contains': [
+                {
+                    'name': 'acceleratorType',
+                    'description': ['The type of...'],
+                    'returned': 'success',
+                },
+                {
+                    'name': 'networkEndpoints',
+                    'contains': [
+                        {
+                            'name': 'ipAddress',
+                            'description': ['The IP address.'],
+                            'type': 'str',
+                        },
+                        {
+                            'name': 'port',
+                            'description': ['The port'],
+                            'type': 'int',
+                        },
+                    ]
+                }
+            ]
+        },
+    ]
+
+
+def test_doc_nested_suboptions(doc_string_loader):
     ansible_doc_output = """
         {
             "my_sample_module": {
@@ -111,7 +296,7 @@ def test_doc_nested_suboptions(loader_module):
     """
     data = json.loads(ansible_doc_output)
     data = list(data.values())[0]
-    transformed_data = loader_module._transform_doc_strings(data)
+    transformed_data = doc_string_loader._transform_doc_strings(data)
     assert transformed_data['doc']['options'] == [
         {
             'name': 'exclude',
@@ -143,99 +328,4 @@ def test_doc_nested_suboptions(loader_module):
                 }
             ]
         }
-    ]
-
-
-def test_return(loader_module):
-    ansible_doc_output = """
-        {
-            "my_sample_module": {
-                "return": {
-                    "message": {
-                        "description": ["The output message the sample module generates"]
-                    },
-                    "original_message": {
-                        "description": ["The original name param that was passed in"],
-                        "type": "str"
-                    }
-                }
-            }
-        }
-    """
-
-    data = json.loads(ansible_doc_output)
-    data = list(data.values())[0]
-    transformed_data = loader_module._transform_doc_strings(data)
-    assert transformed_data['return'] == [
-        {
-            'name': 'message',
-            'description': ['The output message the sample module generates']
-        },
-        {
-            'name': 'original_message',
-            'description': ['The original name param that was passed in'],
-            'type': 'str'
-        }
-    ]
-
-
-def test_return_nested_contains(loader_module):
-    ansible_doc_output = """
-        {
-            "my_sample_module": {
-                "return": {
-                    "resources": {
-                        "contains": {
-                            "acceleratorType": {
-                                "description": ["The type of..."],
-                                "returned": "success"
-                            },
-                            "networkEndpoints": {
-                                "contains": {
-                                    "ipAddress": {
-                                        "description": ["The IP address."],
-                                        "type": "str"
-                                    },
-                                    "port": {
-                                        "description": ["The port"],
-                                        "type": "int"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    """
-
-    data = json.loads(ansible_doc_output)
-    data = list(data.values())[0]
-    transformed_data = loader_module._transform_doc_strings(data)
-    assert transformed_data['return'] == [
-        {
-            'name': 'resources',
-            'contains': [
-                {
-                    'name': 'acceleratorType',
-                    'description': ['The type of...'],
-                    'returned': 'success',
-                },
-                {
-                    'name': 'networkEndpoints',
-                    'contains': [
-                        {
-                            'name': 'ipAddress',
-                            'description': ['The IP address.'],
-                            'type': 'str',
-                        },
-                        {
-                            'name': 'port',
-                            'description': ['The port'],
-                            'type': 'int',
-                        },
-                    ]
-                }
-            ]
-        },
     ]


### PR DESCRIPTION
- Update extract dir to be collections path via metadata names - allows `ansible-doc` to access doc_fragments
- Improve key retrieval from `ansible-doc` output
- Calculate class attrs and fully qualified content name from current path
  - Include support for content existing in subdirectories
- Call ansible-doc with updated path and fully qualified content name

Resolves: https://github.com/ansible/galaxy-dev/issues/121