### PR TITLE
Add openshift job to run ansible-test in container

### DIFF
--- a/galaxy_importer/ansible_test/job_template.yaml
+++ b/galaxy_importer/ansible_test/job_template.yaml
@@ -21,3 +21,4 @@ spec:
             cpu: '1'
             memory: 1Gi
       restartPolicy: Never
+      imagePullPolicy: IfNotPresent  # TODO: change to Always when swith to pulp-container

--- a/galaxy_importer/ansible_test/job_template.yaml
+++ b/galaxy_importer/ansible_test/job_template.yaml
@@ -9,6 +9,7 @@ spec:
   backoffLimit: 0
   template:
     spec:
+      automountServiceAccountToken: false
       containers:
       - name: {job_name}
         image: {image}

--- a/galaxy_importer/ansible_test/job_template.yaml
+++ b/galaxy_importer/ansible_test/job_template.yaml
@@ -1,0 +1,22 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {job_name}
+  labels:
+    app: automation-hub
+spec:
+  activeDeadlineSeconds: 600
+  backoffLimit: 0
+  template:
+    spec:
+      containers:
+      - name: {job_name}
+        image: {image}
+        resources:
+          requests:
+            cpu: 250m
+            memory: 256Mi
+          limits:
+            cpu: '1'
+            memory: 1Gi
+      restartPolicy: Never

--- a/galaxy_importer/ansible_test/runners/openshift_job.py
+++ b/galaxy_importer/ansible_test/runners/openshift_job.py
@@ -16,12 +16,144 @@
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
 
-# from galaxy_importer.ansible_test import container_build
+import os
+import requests
+import time
+from urllib3.exceptions import InsecureRequestWarning
+import uuid
+import yaml
+
+from galaxy_importer import config
+from galaxy_importer import exceptions
 from galaxy_importer.ansible_test.runners.base import BaseTestRunner
+
+
+cfg = config.Config()
+POD_CHECK_RETRIES = 120  # TODO: try to shorten once not pulling image from quay
+POD_CHECK_DELAY_SECONDS = 1
 
 
 class OpenshiftJobTestRunner(BaseTestRunner):
     """Run image as an openshift job."""
     def run(self):
+        # TODO: build image with pulp-container when ready
         # image = container_build.build_image_with_artifact()
-        pass
+        image = 'quay.io/awcrosby/ans-test-with-archive'
+
+        # TODO: add certificate verification if needed within openshift
+        # use this?: kubernetes.io/service-account-token
+        requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
+
+        filename = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'job_template.yaml')
+        with open(filename, 'r') as f:
+            job_template = f.read()
+
+        job = Job(
+            ocp_domain=os.environ['OCP_DOMAIN'],
+            namespace=os.environ['OCP_NAMESPACE'],
+            session_token=os.environ['OCP_SESSION_TOKEN'],
+            image=image,
+            job_template=job_template,
+            logger=self.log,
+        )
+        job.create()
+        job.wait_on_pod_ready()
+        iter_logs = job.get_logs()
+
+        for line in iter_logs:
+            if isinstance(line, bytes):
+                self.log.error('Unexpected bytes in logs: {}'.format(str(line)))
+                continue
+            self.log.info(line)
+
+        job.cleanup()
+
+
+class Job(object):
+    """Interact with Openshift Job via REST API."""
+
+    def __init__(self, ocp_domain, namespace, session_token, image, job_template, logger):
+        self.name = 'ansible-test-' + str(uuid.uuid4())
+        self.auth_header = {'Authorization': f'Bearer {session_token}'}
+        self.jobs_url = f'{ocp_domain}/apis/batch/v1/namespaces/{namespace}/jobs'
+        self.job_name_url = f'{self.jobs_url}/{self.name}'
+        self.pods_url = f'{ocp_domain}/api/v1/namespaces/{namespace}/pods'
+        self.pod_url_template = '{pods_url}/{pod_name}'
+        self.log_url_template = '{pods_url}/{pod_name}/log'
+        self.job_yaml = job_template.format(
+            job_name=self.name,
+            image=image,
+        )
+        self.log = logger
+
+    def create(self):
+        """Create the job."""
+
+        self.log.info(f'Creating job {self.name}')
+        response = requests.post(
+            self.jobs_url,
+            headers=self.auth_header,
+            json=yaml.safe_load(self.job_yaml),
+            verify=False,
+        )
+        if response.status_code != requests.codes.created:
+            raise exceptions.AnsibleTestError('Could not create job')
+
+    def wait_on_pod_ready(self):
+        """Wait until job's pod initializes, pulls image, and starts running."""
+
+        self.log.info('Creating pod...')
+        for i in range(POD_CHECK_RETRIES):
+            pods = self.get_pods()
+            if len(pods) < 1:
+                time.sleep(POD_CHECK_DELAY_SECONDS)
+                continue
+            break
+
+        if len(pods) < 1:
+            self.cleanup()
+            raise exceptions.AnsibleTestError('Could not create pod assocated with job')
+
+        self.log.info('Scheduling pod and waiting until it is running...')
+        for i in range(POD_CHECK_RETRIES):
+            pods = self.get_pods()
+            pod_phase = pods[0]['status']['phase']
+            if pod_phase != 'Pending':
+                return
+            time.sleep(POD_CHECK_DELAY_SECONDS)
+
+        self.log.debug(pods[0]['status'])
+        self.cleanup()
+        raise exceptions.AnsibleTestError('Could not start pod assocated with job')
+
+    def get_pods(self):
+        """Get pods associated with job."""
+        params = {'labelSelector': f'job-name={self.name}'}
+        r = requests.get(self.pods_url, headers=self.auth_header, params=params, verify=False)
+        return r.json()['items']
+
+    @staticmethod
+    def get_pod_name(pod):
+        return pod['metadata']['name']
+
+    def get_logs(self):
+        """Returns stream of lines from the logs of the pod."""
+        pod = self.get_pods()[0]
+        pod_name = self.get_pod_name(pod)
+        r = requests.get(
+                url=f'{self.pods_url}/{pod_name}/log',
+                headers=self.auth_header,
+                params=dict(follow='true'),
+                stream=True,
+                verify=False,
+            )
+        return r.iter_lines(decode_unicode=True)
+
+    def cleanup(self):
+        """Deletes job and any pods associated to it."""
+        pod_names = [self.get_pod_name(pod) for pod in self.get_pods()]
+        requests.delete(self.job_name_url, headers=self.auth_header, verify=False)
+        self.log.debug(f'Deleted job {self.name}')
+        for pod_name in pod_names:
+            requests.delete(f'{self.pods_url}/{pod_name}', headers=self.auth_header, verify=False)
+            self.log.debug(f'Deleted pod {pod_name}')

--- a/galaxy_importer/ansible_test/runners/openshift_job.py
+++ b/galaxy_importer/ansible_test/runners/openshift_job.py
@@ -30,6 +30,7 @@ from galaxy_importer.ansible_test.runners.base import BaseTestRunner
 cfg = config.Config()
 POD_CHECK_RETRIES = 120  # TODO: try to shorten once not pulling image from quay
 POD_CHECK_DELAY_SECONDS = 1
+OCP_TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token'
 
 
 class OpenshiftJobTestRunner(BaseTestRunner):
@@ -46,7 +47,7 @@ class OpenshiftJobTestRunner(BaseTestRunner):
         job = Job(
             ocp_domain=os.environ['OCP_DOMAIN'],
             namespace=os.environ['OCP_NAMESPACE'],
-            session_token=os.environ['OCP_SESSION_TOKEN'],
+            session_token=self.get_token(),
             image=image,
             job_template=job_template,
             logger=self.log,
@@ -62,6 +63,12 @@ class OpenshiftJobTestRunner(BaseTestRunner):
             self.log.info(line)
 
         job.cleanup()
+
+    @staticmethod
+    def get_token():
+        with open(OCP_TOKEN_PATH, 'r') as f:
+            token = f.read().rstrip()
+        return token
 
 
 class Job(object):

--- a/galaxy_importer/ansible_test/runners/openshift_job.py
+++ b/galaxy_importer/ansible_test/runners/openshift_job.py
@@ -17,6 +17,7 @@
 
 
 import os
+import pkg_resources
 import requests
 import time
 import uuid
@@ -31,22 +32,24 @@ cfg = config.Config()
 POD_CHECK_RETRIES = 120  # TODO: try to shorten once not pulling image from quay
 POD_CHECK_DELAY_SECONDS = 1
 OCP_TOKEN_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/token'
+TEMP_IMG_WITH_ARCHIVE = 'quay.io/awcrosby/ans-test-with-archive'
 
 
 class OpenshiftJobTestRunner(BaseTestRunner):
     """Run image as an openshift job."""
     def run(self):
-        # TODO: build image with pulp-container when ready
+        # TODO: change from temp image to build image with pulp-container
         # image = container_build.build_image_with_artifact()
-        image = 'quay.io/awcrosby/ans-test-with-archive'
+        image = TEMP_IMG_WITH_ARCHIVE
 
-        filename = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'job_template.yaml')
-        with open(filename, 'r') as f:
+        template_path = pkg_resources.resource_filename(
+            'galaxy_importer', 'ansible_test/job_template.yaml')
+        with open(template_path, 'r') as f:
             job_template = f.read()
 
         job = Job(
-            ocp_domain=os.environ['OCP_DOMAIN'],
-            namespace=os.environ['OCP_NAMESPACE'],
+            ocp_domain=os.environ['OCP_API_DOMAIN'],
+            namespace=os.environ['OCP_JOB_NAMESPACE'],
             session_token=self.get_token(),
             image=image,
             job_template=job_template,

--- a/galaxy_importer/exceptions.py
+++ b/galaxy_importer/exceptions.py
@@ -21,6 +21,11 @@ class ImporterError(Exception):
     pass
 
 
+class AnsibleTestError(ImporterError):
+    """Exception when running ansible-test."""
+    pass
+
+
 class ManifestNotFound(ImporterError):
     pass
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ install_requires =
     bleach-whitelist>=0.0.10,<1
     markdown>=3.1.1,<4
     pyyaml>=5.1.1,<6
+    requests>=2.22.0,<3
     semantic_version>=2.6.0,<3
 
 [options.extras_require]

--- a/tests/test_runner_openshift_job.py
+++ b/tests/test_runner_openshift_job.py
@@ -1,0 +1,131 @@
+# (c) 2012-2020, Ansible by Red Hat
+#
+# This file is part of Ansible Galaxy
+#
+# Ansible Galaxy is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by
+# the Apache Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Ansible Galaxy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License
+# along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
+
+from types import SimpleNamespace
+
+import pytest
+from pytest_mock import mocker  # noqa F401
+import requests
+
+from galaxy_importer import exceptions as exc
+from galaxy_importer.ansible_test.runners import openshift_job
+
+
+@pytest.fixture
+def job():
+    return openshift_job.Job(
+        'my_domain', 'my_ns', 'session_token', 'image', 'job_template', logger=None)
+
+
+def test_runner_run(mocker, monkeypatch):  # noqa F811
+    mocker.patch.object(openshift_job.OpenshiftJobTestRunner, 'get_token')
+    mocker.patch.object(openshift_job.OpenshiftJobTestRunner, 'get_job_template')
+    mocker.patch.object(openshift_job.Job, 'create')
+    mocker.patch.object(openshift_job.Job, 'wait_on_pod_ready')
+    mocker.patch.object(openshift_job.Job, 'get_logs')
+    mocker.patch.object(openshift_job.Job, 'cleanup')
+
+    openshift_job.Job.get_logs.return_value = ['log_entry', b'bytes_log_entry']
+    monkeypatch.setenv('OCP_API_DOMAIN', 'my_host')
+    monkeypatch.setenv('OCP_JOB_NAMESPACE', 'my_project')
+    runner = openshift_job.OpenshiftJobTestRunner()
+    runner.run()
+
+    assert openshift_job.Job.create.called
+    assert openshift_job.Job.wait_on_pod_ready.called
+    assert openshift_job.Job.get_logs.called
+    assert openshift_job.Job.cleanup.called
+
+
+def test_runner_get_token(mocker, tmp_path):  # noqa F811
+    mocker.patch.object(openshift_job, 'OCP_TOKEN_PATH')
+    p = tmp_path / 'session_token'
+    p.write_text('my_session_token_1234')
+    openshift_job.OCP_TOKEN_PATH = p
+    assert openshift_job.OpenshiftJobTestRunner.get_token() == 'my_session_token_1234'
+
+
+def test_runner_get_job_template(mocker, tmp_path):  # noqa F811
+    job_template = openshift_job.OpenshiftJobTestRunner.get_job_template()
+    assert job_template.startswith('apiVersion: batch/v1\nkind: Job')
+
+
+def test_job_init(job):
+    assert job.jobs_url == 'my_domain/apis/batch/v1/namespaces/my_ns/jobs'
+    assert job.pods_url == 'my_domain/api/v1/namespaces/my_ns/pods'
+
+
+def test_job_create(mocker, job):  # noqa F811
+    mocker.patch.object(requests, 'post')
+
+    requests.post.return_value = SimpleNamespace(status_code=201)
+    job.create()
+    assert requests.post.called
+
+    requests.post.return_value = SimpleNamespace(status_code=500, reason='', text='')
+    with pytest.raises(exc.AnsibleTestError):
+        job.create()
+
+
+def test_job_wait_on_pod_ready(mocker, job):  # noqa F811
+    mocker.patch.object(openshift_job.Job, 'get_pods')
+    mocker.patch.object(openshift_job.Job, 'cleanup')
+    mocker.patch.object(openshift_job, 'POD_CHECK_RETRIES')
+    openshift_job.POD_CHECK_RETRIES = 1
+
+    openshift_job.Job.get_pods.return_value = [{'status': {'phase': 'Running'}}]
+    job.wait_on_pod_ready()
+    assert openshift_job.Job.get_pods.called
+
+    openshift_job.Job.get_pods.return_value = []
+    with pytest.raises(exc.AnsibleTestError):
+        job.wait_on_pod_ready()
+    assert openshift_job.Job.cleanup.called
+
+    openshift_job.Job.get_pods.return_value = [{'status': {'phase': 'Pending'}}]
+    with pytest.raises(exc.AnsibleTestError):
+        job.wait_on_pod_ready()
+    assert openshift_job.Job.cleanup.called
+
+
+def test_job_get_pods(mocker, job):  # noqa F811
+    mocker.patch.object(requests, 'get')
+    requests.get.json.return_value = {}
+    job.get_pods()
+    assert requests.get.called
+
+
+def test_job_get_pod_name():
+    pod = {'metadata': {'name': 'my_pod_name'}}
+    assert openshift_job.Job.get_pod_name(pod) == 'my_pod_name'
+
+
+def test_job_get_logs(mocker, job):  # noqa F811
+    mocker.patch.object(openshift_job.Job, 'get_pods')
+    mocker.patch.object(requests, 'get')
+    openshift_job.Job.get_pods.return_value = [{'metadata': {'name': 'my_pod_name'}}]
+    requests.get.iter_lines.return_value = {}
+    job.get_logs()
+    assert requests.get.called
+
+
+def test_job_cleanup(mocker, job):  # noqa F811
+    mocker.patch.object(openshift_job.Job, 'get_pods')
+    mocker.patch.object(requests, 'delete')
+    openshift_job.Job.get_pods.return_value = [{'metadata': {'name': 'my_pod_name'}}]
+    job.cleanup()
+    assert requests.delete.called


### PR DESCRIPTION
Part of https://github.com/ansible/galaxy-dev/issues/122

Adds openshift job definition that can run depending on the `galaxy-importer` config's infrastructure parameters. This temporarily uses a static image with an artifact already included, it will be updated to use pulp-container.