### PR TITLE
Add cert authority to support openshift local api domain

### DIFF
--- a/galaxy_importer/ansible_test/runners/openshift_job.py
+++ b/galaxy_importer/ansible_test/runners/openshift_job.py
@@ -46,8 +46,8 @@ class OpenshiftJobTestRunner(BaseTestRunner):
         image = TEMP_IMG_WITH_ARCHIVE
 
         job = Job(
-            ocp_domain=os.environ['OCP_API_DOMAIN'],
-            namespace=os.environ['OCP_JOB_NAMESPACE'],
+            ocp_domain=os.environ['IMPORTER_API_DOMAIN'],
+            namespace=os.environ['IMPORTER_JOB_NAMESPACE'],
             session_token=OpenshiftJobTestRunner.get_token(),
             ca_path=OpenshiftJobTestRunner.get_ca_path(),
             image=image,
@@ -68,13 +68,13 @@ class OpenshiftJobTestRunner(BaseTestRunner):
 
     @staticmethod
     def get_token():
-        with open(OCP_SERVICEACCOUNT_PATH + 'token', 'r') as f:
+        with open(os.path.join(OCP_SERVICEACCOUNT_PATH, 'token'), 'r') as f:
             token = f.read().rstrip()
         return token
 
     @staticmethod
     def get_ca_path():
-        return OCP_SERVICEACCOUNT_PATH + 'ca.crt'
+        return os.path.join(OCP_SERVICEACCOUNT_PATH, 'ca.crt')
 
     @staticmethod
     def get_job_template():

--- a/tests/test_runner_openshift_job.py
+++ b/tests/test_runner_openshift_job.py
@@ -39,8 +39,8 @@ def test_runner_run(mocker, monkeypatch):
     mocker.patch.object(openshift_job.Job, 'cleanup')
 
     openshift_job.Job.get_logs.return_value = ['log_entry', b'bytes_log_entry']
-    monkeypatch.setenv('OCP_API_DOMAIN', 'my_host')
-    monkeypatch.setenv('OCP_JOB_NAMESPACE', 'my_project')
+    monkeypatch.setenv('IMPORTER_API_DOMAIN', 'my_host')
+    monkeypatch.setenv('IMPORTER_JOB_NAMESPACE', 'my_project')
     runner = openshift_job.OpenshiftJobTestRunner()
     runner.run()
 

--- a/tests/test_runner_openshift_job.py
+++ b/tests/test_runner_openshift_job.py
@@ -27,7 +27,7 @@ from galaxy_importer.ansible_test.runners import openshift_job
 @pytest.fixture
 def job():
     return openshift_job.Job(
-        'my_domain', 'my_ns', 'session_token', 'image', 'job_template', logger=None)
+        'my_domain', 'my_ns', 'session_token', 'ca_path', 'image', 'job_template', logger=None)
 
 
 def test_runner_run(mocker, monkeypatch):
@@ -51,10 +51,10 @@ def test_runner_run(mocker, monkeypatch):
 
 
 def test_runner_get_token(mocker, tmp_path):
-    mocker.patch.object(openshift_job, 'OCP_TOKEN_PATH')
-    p = tmp_path / 'session_token'
+    mocker.patch.object(openshift_job, 'OCP_SERVICEACCOUNT_PATH')
+    p = tmp_path / 'token'
     p.write_text('my_session_token_1234')
-    openshift_job.OCP_TOKEN_PATH = p
+    openshift_job.OCP_SERVICEACCOUNT_PATH = str(tmp_path) + '/'
     assert openshift_job.OpenshiftJobTestRunner.get_token() == 'my_session_token_1234'
 
 


### PR DESCRIPTION
Tweaks part of ansible/galaxy-dev#122

In order to use the default URL to reach the kubernetes master API from a pod within the cluster, api uses local certificate authority.