### PR TITLE
Update ansible-test image definition

### DIFF
--- a/docker/ansible-test/Dockerfile
+++ b/docker/ansible-test/Dockerfile
@@ -23,9 +23,6 @@ RUN apt-get update -y \
     && chmod +x /entrypoint
 
 ENV HOME /
-ENV LOGNAME=user1
-ENV USER=user1
-
 USER 1000
 
 ENTRYPOINT ["/entrypoint"]

--- a/docker/ansible-test/Dockerfile
+++ b/docker/ansible-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ansible/default-test-container
+FROM quay.io/ansible/default-test-container:1.12
 
 RUN useradd user1 \
         --uid 1000 \

--- a/docker/ansible-test/Dockerfile
+++ b/docker/ansible-test/Dockerfile
@@ -23,6 +23,9 @@ RUN apt-get update -y \
     && chmod +x /entrypoint
 
 ENV HOME /
+ENV LOGNAME=user1
+ENV USER=user1
+
 USER 1000
 
 ENTRYPOINT ["/entrypoint"]

--- a/docker/ansible-test/entrypoint.sh
+++ b/docker/ansible-test/entrypoint.sh
@@ -26,7 +26,10 @@ mv placeholder_namespace/placeholder_name placeholder_namespace/"$NAME"
 mv placeholder_namespace/ "$NAMESPACE"
 cd /ansible_collections/"$NAMESPACE"/"$NAME"
 
-echo "Using $(ansible --version | head -n 1)"
+# Set env var so ansible --version does not error with getpass.getuser()
+export USER=user1
+
+echo "Using $(ansible --version | head -n 1), $(python --version)"
 
 echo "Running ansible-test sanity on $NAMESPACE-$NAME-$VERSION ..."
 # NOTE: skipping some sanity tests

--- a/docker/ansible-test/entrypoint.sh
+++ b/docker/ansible-test/entrypoint.sh
@@ -5,22 +5,25 @@ set -e
 mkdir -p /ansible_collections/placeholder_namespace/placeholder_name
 cd /ansible_collections/placeholder_namespace/placeholder_name
 
-echo "Copying and extracting archive..."
-cp /archive/*.tar.gz .
-tar -xzf *.tar.gz
+echo "Copying and extracting collection archive..."
+cp /archive/archive.tar.gz .
+tar -xzf archive.tar.gz
 
 # Rename placeholders in path
 NAMESPACE=$(python3 -c "import json; f = open('MANIFEST.json'); namespace = json.load(f)['collection_info']['namespace']; print(namespace); f.close")
 NAME=$(python3 -c "import json; f = open('MANIFEST.json'); name = json.load(f)['collection_info']['name']; print(name); f.close")
+VERSION=$(python3 -c "import json; f = open('MANIFEST.json'); version = json.load(f)['collection_info']['version']; print(version); f.close")
 cd ../../
 mv placeholder_namespace/placeholder_name placeholder_namespace/$NAME
 mv placeholder_namespace/ $NAMESPACE
 cd /ansible_collections/$NAMESPACE/$NAME
 
-echo "Running ansible-test sanity..."
+echo "Using $(ansible --version | head -n 1)"
+
+echo "Running ansible-test sanity on $NAMESPACE-$NAME-$VERSION ..."
 # NOTE: skipping some sanity tests
 # "import" and "validate-modules" require sandboxing
 # "pslint" throws ScriptRequiresMissingModules when container is not run as root
-ansible-test sanity --skip-test import --skip-test validate-modules --skip-test pslint --color yes --failure-ok
+ansible-test sanity --skip-test import --skip-test validate-modules --skip-test pslint --failure-ok
 
 exec "$@"

--- a/docker/ansible-test/entrypoint.sh
+++ b/docker/ansible-test/entrypoint.sh
@@ -1,22 +1,30 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 # Extract collection to path needed for ansible-test sanity
 mkdir -p /ansible_collections/placeholder_namespace/placeholder_name
-cd /ansible_collections/placeholder_namespace/placeholder_name
+pushd ansible_collections/ > /dev/null
+pushd placeholder_namespace/placeholder_name/ > /dev/null
 
 echo "Copying and extracting collection archive..."
 cp /archive/archive.tar.gz .
 tar -xzf archive.tar.gz
 
+# Get variables from collection metadata
+read NAMESPACE NAME VERSION < <(python3 <<EOF
+import json
+with open('MANIFEST.json') as fp:
+    metadata = json.load(fp)['collection_info']
+values = metadata['namespace'], metadata['name'], metadata['version']
+print(*values)
+EOF
+)
+
 # Rename placeholders in path
-NAMESPACE=$(python3 -c "import json; f = open('MANIFEST.json'); namespace = json.load(f)['collection_info']['namespace']; print(namespace); f.close")
-NAME=$(python3 -c "import json; f = open('MANIFEST.json'); name = json.load(f)['collection_info']['name']; print(name); f.close")
-VERSION=$(python3 -c "import json; f = open('MANIFEST.json'); version = json.load(f)['collection_info']['version']; print(version); f.close")
-cd ../../
-mv placeholder_namespace/placeholder_name placeholder_namespace/$NAME
-mv placeholder_namespace/ $NAMESPACE
-cd /ansible_collections/$NAMESPACE/$NAME
+popd > /dev/null
+mv placeholder_namespace/placeholder_name placeholder_namespace/"$NAME"
+mv placeholder_namespace/ "$NAMESPACE"
+cd /ansible_collections/"$NAMESPACE"/"$NAME"
 
 echo "Using $(ansible --version | head -n 1)"
 


### PR DESCRIPTION
Part of ansible/galaxy-dev#122

Updating the image definition used to run `ansible-test sanity` on a collection during import.