### PR TITLE
Updates to ansible-test build and run of ocp job

### DIFF
--- a/docker/ansible-test/entrypoint.sh
+++ b/docker/ansible-test/entrypoint.sh
@@ -35,6 +35,7 @@ echo "Running ansible-test sanity on $NAMESPACE-$NAME-$VERSION ..."
 # NOTE: skipping some sanity tests
 # "import" and "validate-modules" require sandboxing
 # "pslint" throws ScriptRequiresMissingModules when container is not run as root
-ansible-test sanity --skip-test import --skip-test validate-modules --skip-test pslint --failure-ok
+# "ansible-doc" is already called for all plugins in import process
+ansible-test sanity --skip-test import --skip-test validate-modules --skip-test pslint --skip-test ansible-doc --color no --failure-ok
 
 exec "$@"

--- a/galaxy_importer/ansible_test/build_template.yaml
+++ b/galaxy_importer/ansible_test/build_template.yaml
@@ -15,11 +15,14 @@ spec:
       name: {image_name}
   source:
     dockerfile: |
-      FROM awcrosby/galaxy-ansible-test:latest
+      FROM ansible/default-test-container:latest
       RUN wget '{download_url}' -O /archive/archive.tar.gz
   strategy:
     type: Docker
-    dockerStrategy: {{}}
+    dockerStrategy:
+      from:
+        kind: ImageStreamTag
+        name: ansible-test:stable
   triggers:
   - type: ConfigChange
   imagePullPolicy: IfNotPresent

--- a/galaxy_importer/ansible_test/runners/openshift_job.py
+++ b/galaxy_importer/ansible_test/runners/openshift_job.py
@@ -112,7 +112,7 @@ class Build(object):
     """Interact with Openshift builds via REST API."""
     def __init__(self, ocp_domain, namespace, session_token,
                  ca_path, build_template, archive_url, logger):
-        self.name = 'build-' + str(uuid.uuid4())
+        self.name = 'import-' + str(uuid.uuid4())
         self.auth_header = {'Authorization': f'Bearer {session_token}'}
         self.ca_path = ca_path
         self.api_build_prefix = f'{ocp_domain}/apis/build.openshift.io/v1/namespaces/{namespace}'
@@ -136,7 +136,7 @@ class Build(object):
         self._wait_until_image_available()
 
         imagestream_tag = self._get_image()
-        return imagestream_tag['image']['dockerImageReference']
+        return imagestream_tag['metadata']['name']
 
     def _create_buildconfig(self):
         self.log.info(f'Creating buildconfig {self.name}')

--- a/tests/test_runner_openshift_job.py
+++ b/tests/test_runner_openshift_job.py
@@ -250,8 +250,8 @@ def test_build_start_and_get_image_link(mocker, build):
     mocker.patch.object(openshift_job.Build, '_wait_until_image_available')
     mocker.patch.object(openshift_job.Build, '_get_image')
     openshift_job.Build._get_image.return_value = {
-        'image': {'dockerImageReference': 'my_image_link'}}
-    assert build.start_and_get_image_link() == 'my_image_link'
+        'metadata': {'name': 'image_stream_tag_name'}}
+    assert build.start_and_get_image_link() == 'image_stream_tag_name'
     assert openshift_job.Build._create_buildconfig.called
     assert openshift_job.Build._wait_until_build_created.called
     assert openshift_job.Build._wait_until_build_complete.called


### PR DESCRIPTION
* Have ansible-test build and job work off same ImageStream
* Have ansible-test openshift job use `stable` tag of ImageStream
* Within job use ImageStreamTag name rather than docker image url, as reflected in updated PR https://github.com/ansible/galaxy-importer/pull/48
* Skip ansible-doc inside ansible-test sanity run