### PR TITLE
Include root path with relative path for file access

### DIFF
--- a/galaxy_importer/loaders.py
+++ b/galaxy_importer/loaders.py
@@ -304,7 +304,7 @@ class RoleLoader(ContentLoader):
 
     def _get_metadata_description(self):
         description = None
-        meta_path = self._find_metadata_file_path(self.rel_path)
+        meta_path = self._find_metadata_file_path(self.root, self.rel_path)
 
         if not meta_path:
             self.log.warning('Could not get role description, no role metadata found')
@@ -322,10 +322,10 @@ class RoleLoader(ContentLoader):
         return description
 
     @staticmethod
-    def _find_metadata_file_path(rel_path):
+    def _find_metadata_file_path(root, rel_path):
         """Gets path to role metadata file."""
         for file in ROLE_META_FILES:
-            meta_path = os.path.join(rel_path, file)
+            meta_path = os.path.join(root, rel_path, file)
             if os.path.exists(meta_path):
                 return meta_path
         return None

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -293,14 +293,16 @@ def test_ansible_lint_exception(mocked_popen, loader_role):
 
 
 def test_find_metadata_file_path(temp_root, loader_role):
-    res = loader_role._find_metadata_file_path(temp_root)
+    root, rel_path = os.path.split(temp_root)
+
+    res = loader_role._find_metadata_file_path(root, rel_path)
     assert res is None
 
     meta_dir = os.path.join(temp_root, 'meta')
     os.mkdir(meta_dir)
     with open(os.path.join(meta_dir, 'main.yml'), 'w'):
         pass
-    res = loader_role._find_metadata_file_path(temp_root)
+    res = loader_role._find_metadata_file_path(root, rel_path)
     assert res == os.path.join(temp_root, 'meta', 'main.yml')
 
 


### PR DESCRIPTION
Makes explicit the path to look for a file, instead of relying on implicit current working directory. 

This fixes issue where file could not be found on certain environments (docker galaxy-dev setup to support https://github.com/ansible/galaxy_ng/issues/49)