### PR TITLE
Run flake8 on plugins per config

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Example configuration file:
 ```
 [galaxy-importer]
 LOG_LEVEL_MAIN = INFO
+RUN_FLAKE8 = False
 RUN_ANSIBLE_TEST = False
 INFRA_PULP = False
 INFRA_OSD = False

--- a/galaxy_importer/collection.py
+++ b/galaxy_importer/collection.py
@@ -59,7 +59,7 @@ def _import_collection(file, filename, logger, cfg):
         extract_dir = os.path.join(tmp_dir, sub_path)
         with tarfile.open(fileobj=file, mode='r') as pkg_tar:
             pkg_tar.extractall(extract_dir)
-        data = CollectionLoader(extract_dir, filename, logger=logger).load()
+        data = CollectionLoader(extract_dir, filename, cfg=cfg, logger=logger).load()
         logger.info('Collection validation and loading complete')
 
         ansible_test_runner = runners.get_runner(cfg=cfg)
@@ -80,10 +80,11 @@ def _import_collection(file, filename, logger, cfg):
 class CollectionLoader(object):
     """Loads collection and content info."""
 
-    def __init__(self, path, filename, logger=None):
+    def __init__(self, path, filename, cfg=None, logger=None):
         self.log = logger or default_logger
         self.path = path
         self.filename = filename
+        self.cfg = cfg
 
         self.content_objs = None
         self.metadata = None
@@ -154,7 +155,8 @@ class CollectionLoader(object):
         found_contents = ContentFinder().find_contents(self.path, self.log)
         for content_type, rel_path in found_contents:
             loader_cls = loaders.get_loader_cls(content_type)
-            loader = loader_cls(content_type, rel_path, self.path, self.doc_strings, self.log)
+            loader = loader_cls(
+                content_type, rel_path, self.path, self.doc_strings, self.cfg, self.log)
             content_obj = loader.load()
 
             yield content_obj

--- a/galaxy_importer/config.py
+++ b/galaxy_importer/config.py
@@ -32,6 +32,7 @@ class Config(object):
 
     DEFAULTS = {
         'log_level_main': 'INFO',
+        'run_flake8': False,
         'run_ansible_test': False,
         'infra_pulp': False,
         'infra_osd': False,

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ install_requires =
     attrs>=18.2.0,<20
     bleach>=3.1.0,<4
     bleach-whitelist>=0.0.10,<1
+    flake8>=3.7.9,<4
     markdown>=3.1.1,<4
     pyyaml>=5.1.1,<6
     requests>=2.22.0,<3
@@ -40,5 +41,5 @@ galaxy_importer =
     ansible_test/build_template.yaml
 
 [coverage:report]
-fail_under = 93.0
+fail_under = 93.8
 precision = 2


### PR DESCRIPTION
Add a config option to run `flake8` on plugins, defaulted to false. This flake8 is separate from the linting in `ansible-test sanity`.

This supports an environment that does not want to run ansible-test sanity, but still wants flake8 linting on plugins. For example today Community Galaxy runs `flake8` on plugins, and does not run `ansible-test sanity`.

Supports https://github.com/ansible/galaxy_ng/issues/49