### PR TITLE
Parameterize openshift container sizing to fix scheduling issues

### DIFF
--- a/CHANGES/122.bugfix
+++ b/CHANGES/122.bugfix
@@ -1,0 +1,1 @@
+Parameterize openshift container sizing to fix scheduling issues

--- a/galaxy_importer/ansible_test/job_template.yaml
+++ b/galaxy_importer/ansible_test/job_template.yaml
@@ -15,10 +15,10 @@ spec:
         image: {image}
         resources:
           requests:
-            cpu: 500m
-            memory: 512Mi
+            cpu: {cpu_request}
+            memory: {memory_request}
           limits:
-            cpu: 1
-            memory: 1Gi
+            cpu: {cpu_limit}
+            memory: {memory_limit}
       restartPolicy: Never
       imagePullPolicy: IfNotPresent

--- a/galaxy_importer/ansible_test/runners/openshift_job.py
+++ b/galaxy_importer/ansible_test/runners/openshift_job.py
@@ -232,6 +232,10 @@ class Job(object):
         self.job_yaml = job_template.format(
             job_name=self.name,
             image=image,
+            memory_request=os.environ.get('IMPORTER_MEMORY_REQUEST', '256Mi'),
+            memory_limit=os.environ.get('IMPORTER_MEMORY_LIMIT', '1Gi'),
+            cpu_request=os.environ.get('IMPORTER_CPU_REQUEST', '500m'),
+            cpu_limit=os.environ.get('IMPORTER_CPU_LIMIT', '500m'),
         )
         self.log = logger or default_logger
 


### PR DESCRIPTION
Works https://github.com/ansible/galaxy_ng/issues/122

This PR adds parameters to openshift ansible-test container resources.

This allows for config to address container scheduling delays in CI and QA (i.e. lower `requests` and lower `limits` `cpu`) The lower cpu does not do a regression on the recent OOM issue https://github.com/ansible/galaxy_ng/issues/64.