### PR TITLE
Fix traceback and improve output on unexpected docstring format

### DIFF
--- a/CHANGES/159.bugfix
+++ b/CHANGES/159.bugfix
@@ -1,0 +1,1 @@
+Fix traceback and improve output on unexpected docstring format

--- a/galaxy_importer/loaders.py
+++ b/galaxy_importer/loaders.py
@@ -235,19 +235,27 @@ class DocStringLoader():
     def _process_doc_strings(self, doc_strings):
         processed_doc_strings = {}
         for plugin_key, value in doc_strings.items():
-            processed_doc_strings[plugin_key] = self._transform_doc_strings(value)
+            processed_doc_strings[plugin_key] = self._transform_doc_strings(value, self.log)
         return processed_doc_strings
 
     @staticmethod
-    def _transform_doc_strings(data):
+    def _transform_doc_strings(data, logger=default_logger):
         """Transform data meant for UI tables into format suitable for UI."""
 
         def dict_to_named_list(dict_of_dict):
             """Return new list of dicts for given dict of dicts."""
-            return [
-                {'name': key, **deepcopy(dict_of_dict[key])} for
-                key in dict_of_dict.keys()
-            ]
+            try:
+                return [
+                    {'name': key, **deepcopy(dict_of_dict[key])} for
+                    key in dict_of_dict.keys()
+                ]
+            except TypeError:
+                logger.warning(f'Expected this to be a dictionary of dictionaries: {dict_of_dict}')
+                return [
+                    {'name': key, **deepcopy(dict_of_dict[key])} for
+                    key in dict_of_dict.keys()
+                    if isinstance(key, dict)
+                ]
 
         def handle_nested_tables(obj, table_key):
             """Recurse over dict to replace nested tables with updated format."""

--- a/tests/test_loader_doc_strings.py
+++ b/tests/test_loader_doc_strings.py
@@ -240,6 +240,34 @@ def test_transform_doc_strings_nested_contains(doc_string_loader):
     ]
 
 
+def test_transform_doc_strings_nested_contains_dict_of_list(doc_string_loader):
+    ansible_doc_output = """
+        {
+            "my_sample_module": {
+                "return": {
+                    "output": {
+                        "contains": {
+                            "formatted_output": [
+                                "Contains formatted response ..."
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    """
+    data = json.loads(ansible_doc_output)
+    data = list(data.values())[0]
+    transformed_data = doc_string_loader._transform_doc_strings(data)
+    assert transformed_data['return'] == [
+        {
+            'name': 'output',
+            'contains': [
+            ]
+        },
+    ]
+
+
 def test_transform_doc_strings_nested_suboptions(doc_string_loader):
     ansible_doc_output = """
         {


### PR DESCRIPTION
Works https://github.com/ansible/galaxy_ng/issues/159

This PR warns on unexpected docstring format, and allows import to continue. It also removes unexpected format and results in a `"contains": []`