### PR TITLE
Set config file from an env variable

### DIFF
--- a/CHANGES/148.feature
+++ b/CHANGES/148.feature
@@ -1,0 +1,1 @@
+Override default configuration file paths with an environment variable

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ An optional ini configuration file is supported, the following locations are che
 <code_source>/galaxy_importer/galaxy-importer.cfg
 ```
 
+You can override the above paths by setting `GALAXY_IMPORTER_CONFIG` in the environment. For example:
+
+```
+$ export GALAXY_IMPORTER_CONFIG=~/galaxy-importer.cfg
+```
+
 Example configuration file:
 
 ```

--- a/galaxy_importer/config.py
+++ b/galaxy_importer/config.py
@@ -51,6 +51,9 @@ class ConfigFile(object):
 
     @staticmethod
     def load():
+        env_config = os.getenv('GALAXY_IMPORTER_CONFIG')
+        if env_config:
+            FILE_LOCATIONS.insert(0, env_config)
         config_parser_data = ConfigFile._load_file(FILE_LOCATIONS)
         return ConfigFile._to_dictionary(config_parser_data)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,6 +32,16 @@ def temp_config_file():
         os.remove(config_file)
 
 
+@pytest.fixture
+def temp_config_file_b():
+    try:
+        dir = os.path.dirname(os.path.dirname(__file__))
+        config_file = os.path.join(dir, 'galaxy_importer', 'galaxy-importer-b.cfg')
+        yield config_file
+    finally:
+        os.remove(config_file)
+
+
 def test_config_set_from_file(temp_config_file):
     with open(temp_config_file, 'w') as f:
         f.write('[galaxy-importer]\nRUN_ANSIBLE_TEST = True\n'
@@ -43,6 +53,18 @@ def test_config_set_from_file(temp_config_file):
         assert cfg.run_ansible_test is True
         assert cfg.infra_pulp is True
         assert cfg.infra_osd is False
+
+
+def test_config_set_from_env(temp_config_file_b, monkeypatch):
+    with open(temp_config_file_b, 'w') as f:
+        f.write('[galaxy-importer]\nRUN_ANSIBLE_TEST = True\n'
+                'INFRA_PULP = True')
+        f.flush()
+        monkeypatch.setenv('GALAXY_IMPORTER_CONFIG', temp_config_file_b)
+        config_data = config.ConfigFile.load()
+        cfg = config.Config(config_data=config_data)
+        assert cfg.run_ansible_test is True
+        assert cfg.infra_pulp is True
 
 
 def test_config_no_file():


### PR DESCRIPTION
Set `GALAXY_IMPORTER_CONFIG` in the environment to override default config file path.