### PR TITLE
Return non-zero on errors

### DIFF
--- a/CHANGES/66.bugfix
+++ b/CHANGES/66.bugfix
@@ -1,0 +1,1 @@
+Returns non-zero exit code on failure to enable use in shell scripts.

--- a/galaxy_importer/main.py
+++ b/galaxy_importer/main.py
@@ -40,7 +40,7 @@ def main(args=None):
 
     data = call_importer(filepath=args.file, cfg=cfg)
     if not data:
-        return
+        return 1
 
     if args.print_result:
         print(json.dumps(data, indent=4))


### PR DESCRIPTION
When running this as a validity check in a script, it's very
useful if an unsuccessful run returns a non-zero error code.