### PR TITLE
Parameterize ansible-test openshift job container timeout

### DIFF
--- a/CHANGES/230.bugfix
+++ b/CHANGES/230.bugfix
@@ -1,0 +1,1 @@
+Parameterize ansible-test openshift job container timeout

--- a/galaxy_importer/ansible_test/job_template.yaml
+++ b/galaxy_importer/ansible_test/job_template.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: automation-hub
 spec:
-  activeDeadlineSeconds: 600
+  activeDeadlineSeconds: {job_timeout}
   backoffLimit: 0
   template:
     spec:

--- a/galaxy_importer/ansible_test/runners/openshift_job.py
+++ b/galaxy_importer/ansible_test/runners/openshift_job.py
@@ -236,6 +236,7 @@ class Job(object):
             memory_limit=os.environ.get('IMPORTER_MEMORY_LIMIT', '1Gi'),
             cpu_request=os.environ.get('IMPORTER_CPU_REQUEST', '500m'),
             cpu_limit=os.environ.get('IMPORTER_CPU_LIMIT', '500m'),
+            job_timeout=os.environ.get('IMPORTER_JOB_TIMEOUT', '900'),
         )
         self.log = logger or default_logger
 


### PR DESCRIPTION
Parameterize job timeout to control outside galaxy-importer

Works https://github.com/ansible/galaxy_ng/issues/230