### PR TITLE
Increase OpenShift image build timeouts

### DIFF
--- a/CHANGES/345.bugfix
+++ b/CHANGES/345.bugfix
@@ -1,0 +1,1 @@
+Timeouts for OpenShift image build is increased and made configurable via environment variables: ``IMPORTER_JOB_API_CHECK_RETRIES`` and ``IMPORTER_JOB_API_CHECK_DELAY_SECONDS``.

--- a/galaxy_importer/ansible_test/runners/openshift_job.py
+++ b/galaxy_importer/ansible_test/runners/openshift_job.py
@@ -32,8 +32,9 @@ from galaxy_importer.ansible_test.runners.base import BaseTestRunner
 default_logger = logging.getLogger(__name__)
 
 cfg = config.Config()
-API_CHECK_RETRIES = 300
-API_CHECK_DELAY_SECONDS = 1
+# TODO(cutwater): Implement individual timeouts for each step.
+API_CHECK_RETRIES = int(os.environ.get('IMPORTER_JOB_API_CHECK_RETRIES', '300'))
+API_CHECK_DELAY_SECONDS = int(os.environ.get('IMPORTER_JOB_API_CHECK_DELAY_SECONDS', '3'))
 OCP_SERVICEACCOUNT_PATH = '/var/run/secrets/kubernetes.io/serviceaccount/'
 IMAGE_BASE_NAME = 'ansible-test'
 


### PR DESCRIPTION
Timeouts for OpenShift image build is increased and made configurable via environment variables: ``IMPORTER_JOB_API_CHECK_RETRIES`` and ``IMPORTER_JOB_API_CHECK_DELAY_SECONDS``.

Resolves: ansible/galaxy_ng#345