### PR TITLE
Fix CI scripts for non-default branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ language: python
 python: 3.6
 
 before_install:
+  - git fetch origin "+refs/heads/${TRAVIS_BRANCH}:refs/remotes/origin/${TRAVIS_BRANCH}"
   - REGEXP="CHANGES\/[0-9]+\.(feature|bugfix|doc|removal|misc)$"
-  - PR_FILES=$(git diff --name-only $TRAVIS_BRANCH...HEAD)
+  - PR_FILES=$(git diff --name-only ${TRAVIS_BRANCH})
   - for file in $PR_FILES; do
       echo $file;
       if [[ $file =~ $REGEXP ]]; then


### PR DESCRIPTION
When pull request is targeted to non-default branch (i.e. any branch
except master), Travis CI job fails with the following error:

```
  fatal: ambiguous argument 'stable/0.2.8...HEAD': unknown revision or path not in the working tree.
  Use '--' to separate paths from revisions, like this:
  'git <command> [<revision>...] -- [<file>...]'
  The command "PR_FILES=$(git diff --name-only $TRAVIS_BRANCH...HEAD)" failed and exited with 128 during .
```