### PR TITLE
Use explicit OpenShift registry reference

### DIFF
--- a/CHANGES/350.bugfix
+++ b/CHANGES/350.bugfix
@@ -1,0 +1,1 @@
+Fixed OpenShift Job referencing image by name only. Replaced `.metadata.name` with `.image.dockerImageReference`.

--- a/galaxy_importer/ansible_test/runners/openshift_job.py
+++ b/galaxy_importer/ansible_test/runners/openshift_job.py
@@ -137,7 +137,7 @@ class Build(object):
         self._wait_until_image_available()
 
         imagestream_tag = self._get_image()
-        return imagestream_tag['metadata']['name']
+        return imagestream_tag['image']['dockerImageReference']
 
     def _create_buildconfig(self):
         self.log.info(f'Creating buildconfig {self.name}')

--- a/tests/test_runner_openshift_job.py
+++ b/tests/test_runner_openshift_job.py
@@ -281,8 +281,8 @@ def test_build_start_and_get_image_link(mocker, build):
     mocker.patch.object(openshift_job.Build, '_wait_until_image_available')
     mocker.patch.object(openshift_job.Build, '_get_image')
     openshift_job.Build._get_image.return_value = {
-        'metadata': {'name': 'image_stream_tag_name'}}
-    assert build.start_and_get_image_link() == 'image_stream_tag_name'
+        'image': {'dockerImageReference': 'registry.example.com/image_stream_tag_name'}}
+    assert build.start_and_get_image_link() == 'registry.example.com/image_stream_tag_name'
     assert openshift_job.Build._create_buildconfig.called
     assert openshift_job.Build._wait_until_build_created.called
     assert openshift_job.Build._wait_until_build_complete.called


### PR DESCRIPTION
OpenShift Job runner used image <name>:<tag> as a reference to a
image stream tag. This reference is ambiguous, becuase it depends
on a OpenShift image lookup configuration.
With this patch a field `.image.dockerImageReference` of ImageStreamTag
is used to reference an image for a Job.

Closes: ansible/galaxy_ng#350