### PR TITLE
Check for binaries before executing them

### DIFF
--- a/CHANGES/355.misc
+++ b/CHANGES/355.misc
@@ -1,0 +1,1 @@
+Check for binaries before executing them

--- a/galaxy_importer/ansible_test/runners/local_ansible_test.py
+++ b/galaxy_importer/ansible_test/runners/local_ansible_test.py
@@ -17,6 +17,7 @@
 
 
 import os
+import shutil
 import subprocess
 
 from galaxy_importer.ansible_test.runners.base import BaseTestRunner
@@ -25,6 +26,10 @@ from galaxy_importer.ansible_test.runners.base import BaseTestRunner
 class LocalAnsibleTestRunner(BaseTestRunner):
     """Run ansible-test locally with --docker or using venv."""
     def run(self):
+        if not shutil.which('ansible'):
+            self.log.error('ansible not found, skipping ansible-test')
+            return
+
         version_proc = subprocess.Popen(
             ['ansible', '--version'],
             stdout=subprocess.PIPE,

--- a/galaxy_importer/loaders.py
+++ b/galaxy_importer/loaders.py
@@ -22,6 +22,7 @@ import logging
 import os
 from pathlib import Path
 import re
+import shutil
 from subprocess import Popen, PIPE
 import yaml
 
@@ -138,6 +139,11 @@ class PluginLoader(ContentLoader):
 
     def _run_flake8(self, path):
         self.log.info(f'Linting {self.content_type.value} {self.path_name} via flake8...')
+
+        if not shutil.which('flake8'):
+            self.log.warning('flake8 not found, skipping')
+            return
+
         cmd = [
             'flake8', '--exit-zero', '--isolated',
             '--extend-ignore', FLAKE8_IGNORE_ERRORS,
@@ -179,6 +185,10 @@ class DocStringLoader():
     def load(self):
         self.log.info('Getting doc strings via ansible-doc')
         docs = {}
+
+        if not shutil.which('ansible-doc'):
+            self.log.warning('ansible-doc not found, skipping loading of docstrings')
+            return docs
 
         for plugin_type in ANSIBLE_DOC_SUPPORTED_TYPES:
             plugin_dir_name = ANSIBLE_DOC_PLUGIN_MAP.get(plugin_type, plugin_type)
@@ -309,6 +319,11 @@ class RoleLoader(ContentLoader):
 
     def _lint_role(self, path):
         self.log.info(f'Linting role {self.path_name} via ansible-lint...')
+
+        if not shutil.which('ansible-lint'):
+            self.log.warning('ansible-lint not found, skipping lint of role')
+            return
+
         cmd = [
             'ansible-lint', path,
             '-p',

--- a/tests/unit/test_loader_doc_strings.py
+++ b/tests/unit/test_loader_doc_strings.py
@@ -394,3 +394,15 @@ def test_load_ansible_doc_error(mocked_popen, doc_string_loader, tmpdir):
 
     res = doc_string_loader.load()
     assert res == {'inventory': {}}
+
+
+@mock.patch('shutil.which')
+def test_no_ansible_doc_bin(mocked_shutil_which, doc_string_loader, tmpdir, caplog):
+    mocked_shutil_which.return_value = False
+
+    doc_string_loader.path = str(tmpdir)
+    tmpdir.mkdir('plugins').mkdir('inventory').join('my_plugin.py').write('')
+
+    doc_string_loader.load()
+    assert 'ansible-doc not found, skipping loading of docstrings' in \
+        [r.message for r in caplog.records]

--- a/tests/unit/test_loaders.py
+++ b/tests/unit/test_loaders.py
@@ -374,3 +374,22 @@ def test_load_role(mocked_lint_role, temp_root, loader_role):
     assert res.name == 'my_sample_role'
     assert res.content_type == constants.ContentType.ROLE
     assert res.description == 'Test description inside metadata'
+
+
+@mock.patch('shutil.which')
+def test_no_flake8_bin(mocked_shutil_which, loader_module, caplog):
+    mocked_shutil_which.return_value = False
+    assert loader_module.name == 'my_module'
+    loader_module.load()
+    assert 'flake8 not found, skipping' in [r.message for r in caplog.records]
+
+
+@mock.patch('shutil.which')
+def test_no_ansible_lint_bin(mocked_shutil_which, temp_root, loader_role, caplog):
+    mocked_shutil_which.return_value = False
+    loader_role.root = ''
+    loader_role.rel_path = temp_root
+    with open(os.path.join(temp_root, 'README.md'), 'w') as fp:
+        fp.write('This is the role readme text')
+    loader_role.load()
+    assert 'ansible-lint not found, skipping lint of role' in [r.message for r in caplog.records]

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -19,6 +19,7 @@ import logging
 import os
 import subprocess
 from types import SimpleNamespace
+from unittest import mock
 
 import pytest
 
@@ -121,3 +122,13 @@ def test_local_run_rc_error(mocker, caplog):
     assert len(caplog.records) == 5
     assert caplog.records[4].levelname == 'ERROR'
     assert 'An exception occurred in ansible-test sanity' in str(caplog.records[4])
+
+
+@mock.patch('shutil.which')
+def test_local_no_ansible_bin(mocked_shutil_which, caplog):
+    mocked_shutil_which.return_value = False
+    metadata = SimpleNamespace(
+        namespace='test_ns', name='test_name', version='test_version')
+    runner = runners.local_ansible_test.LocalAnsibleTestRunner(metadata=metadata)
+    runner.run()
+    assert 'ansible not found, skipping ansible-test' in [r.message for r in caplog.records]


### PR DESCRIPTION
Closes-Issue: #355

Notify user in logs when binary such as ansible-lint is missing

Signed-off-by: Andrew Crosby <acrosby@redhat.com>