### PR TITLE
Enable running ansible-test via Podman

### DIFF
--- a/CHANGES/5.feature
+++ b/CHANGES/5.feature
@@ -1,0 +1,1 @@
+Enables running ansible-test via Podman.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ RUN_ANSIBLE_DOC = True
 RUN_ANSIBLE_LINT = True
 RUN_ANSIBLE_TEST = False
 ANSIBLE_TEST_LOCAL_IMAGE = False
+LOCAL_IMAGE_DOCKER = False
 INFRA_OSD = False
 TMP_ROOT_DIR = None
 ANSIBLE_LOCAL_TMP = '~/.ansible/tmp'
@@ -53,7 +54,9 @@ ANSIBLE_LOCAL_TMP = '~/.ansible/tmp'
 
 - `RUN_ANSIBLE_TEST` - Set to `True` to run `ansible-test` during collection import. Defaults to `False`.
 
-- `ANSIBLE_TEST_LOCAL_IMAGE` - Set to `True` to run `ansible-test` sandboxed within a container image. Requires installation of Docker to run the container. Defaults to `False`.
+- `ANSIBLE_TEST_LOCAL_IMAGE` - Set to `True` to run `ansible-test` sandboxed within a container image. Requires installation of either Podman or Docker to run the container. Defaults to `False`.
+
+- `LOCAL_IMAGE_DOCKER` - Set to `True` to run the `ansible-test` container image via Docker; otherwise, Podman will be used. Defaults to `False`.
 
 ### Issues and Process
 

--- a/galaxy_importer/ansible_test/runners/local_image.py
+++ b/galaxy_importer/ansible_test/runners/local_image.py
@@ -15,11 +15,13 @@
 # You should have received a copy of the Apache License
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
+import shutil
+from subprocess import Popen, PIPE, STDOUT
+
 from galaxy_importer import config
 from galaxy_importer import exceptions
 from galaxy_importer.ansible_test.builders.local_image_build import Build
 from galaxy_importer.ansible_test.runners.base import BaseTestRunner
-from subprocess import Popen, PIPE, STDOUT
 
 
 class LocalImageTestRunner(BaseTestRunner):
@@ -33,12 +35,18 @@ class LocalImageTestRunner(BaseTestRunner):
             cfg,
             self.log)
 
+        container_engine = build.get_container_engine(cfg)
+
+        if not shutil.which(container_engine):
+            self.log.warning(f'"{container_engine}" not found, skipping ansible-test sanity')
+            return
+
         image_id = build.build_image()
 
         self.log.info('Running image...')
         self._run_image(
             image_id=image_id,
-            container_engine=build.get_container_engine(cfg)
+            container_engine=container_engine
         )
 
         build.cleanup()

--- a/galaxy_importer/ansible_test/runners/local_image.py
+++ b/galaxy_importer/ansible_test/runners/local_image.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the Apache License
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
+from galaxy_importer import config
 from galaxy_importer import exceptions
 from galaxy_importer.ansible_test.builders.local_image_build import Build
 from galaxy_importer.ansible_test.runners.base import BaseTestRunner
@@ -24,20 +25,26 @@ from subprocess import Popen, PIPE, STDOUT
 class LocalImageTestRunner(BaseTestRunner):
     """Run image locally with docker or podman."""
     def run(self):
+        cfg = config.Config(config_data=config.ConfigFile.load())
+
         build = Build(
             self.filepath,
             f'{self.metadata.namespace}-{self.metadata.name}-{self.metadata.version}',
+            cfg,
             self.log)
 
         image_id = build.build_image()
 
         self.log.info('Running image...')
-        self._run_image(image_id=image_id)
+        self._run_image(
+            image_id=image_id,
+            container_engine=build.get_container_engine(cfg)
+        )
 
         build.cleanup()
 
-    def _run_image(self, image_id):
-        cmd = ['docker', 'run', image_id, 'LOCAL_IMAGE_RUNNER']
+    def _run_image(self, image_id, container_engine):
+        cmd = [container_engine, 'run', image_id, 'LOCAL_IMAGE_RUNNER']
         proc = Popen(
             cmd,
             stdout=PIPE,

--- a/tests/unit/test_builder_local_image.py
+++ b/tests/unit/test_builder_local_image.py
@@ -74,7 +74,7 @@ def test_build_image_with_artifact(mocked_popen, mocker):
     with tempfile.TemporaryDirectory() as dir:
         mocked_popen.return_value.stdout = ['sha256:1234', 'sha256:5678']
         mocked_popen.return_value.wait.return_value = 0
-        result = Build._build_image_with_artifact(dir=dir)
+        result = Build._build_image_with_artifact(dir=dir, container_engine='podman')
         assert mocked_popen.called
         assert '5678' in result
 
@@ -85,7 +85,7 @@ def test_build_image_with_artifact_exception(mocked_popen, mocker):
         mocked_popen.return_value.stdout = ['sha256:1234', 'sha256:5678']
         mocked_popen.return_value.wait.return_value = 1
         with pytest.raises(exc.AnsibleTestError):
-            Build._build_image_with_artifact(dir=dir)
+            Build._build_image_with_artifact(dir=dir, container_engine='podman')
 
 
 def test_copy_collection_file():

--- a/tests/unit/test_runner_local_image.py
+++ b/tests/unit/test_runner_local_image.py
@@ -39,6 +39,7 @@ def test_runner_run(metadata, mocker):
 
     mocker.patch.object(Build, 'build_image')
     mocker.patch.object(Build, 'cleanup')
+    mocker.patch.object(Build, 'get_container_engine')
     mocker.patch.object(runner, '_run_image')
 
     runner.run()
@@ -46,6 +47,7 @@ def test_runner_run(metadata, mocker):
     assert Build.build_image.called
     assert runner._run_image.called
     assert Build.cleanup.called
+    assert Build.get_container_engine.called
 
 
 @mock.patch('galaxy_importer.ansible_test.runners.local_image.Popen')
@@ -54,7 +56,7 @@ def test_run_image(mocked_popen, metadata):
     mocked_popen.return_value.stdout = ['test 1 ran', 'test2 ran']
     mocked_popen.return_value.wait.return_value = 0
 
-    runner._run_image('galaxy-importer:tag')
+    runner._run_image('1234', 'podman')
 
     assert mocked_popen.called
 
@@ -66,4 +68,4 @@ def test_run_image_exception(mocked_popen, metadata):
     mocked_popen.return_value.wait.return_value = 1
 
     with pytest.raises(exc.AnsibleTestError):
-        runner._run_image('galaxy-importer:tag')
+        runner._run_image('1234', 'podman')

--- a/tests/unit/test_runner_local_image.py
+++ b/tests/unit/test_runner_local_image.py
@@ -17,6 +17,7 @@
 
 import logging
 import pytest
+import shutil
 
 from galaxy_importer.ansible_test.builders.local_image_build import Build
 from galaxy_importer import exceptions as exc
@@ -35,7 +36,8 @@ def metadata():
     return SimpleNamespace(namespace='test_ns', name='test_name', version='test_version')
 
 
-def test_runner_run(metadata, mocker):
+@mock.patch('shutil.which')
+def test_runner_run(mocked_shutil_which, metadata, mocker):
     runner = runners.local_image.LocalImageTestRunner(metadata=metadata)
 
     mocker.patch.object(Build, 'build_image')
@@ -43,6 +45,7 @@ def test_runner_run(metadata, mocker):
     mocker.patch.object(Build, 'get_container_engine')
     mocker.patch.object(runner, '_run_image')
     Build.get_container_engine.return_value = 'podman'
+    shutil.which.return_value = True
 
     runner.run()
 
@@ -52,7 +55,8 @@ def test_runner_run(metadata, mocker):
     assert Build.get_container_engine.called
 
 
-def test_runner_run_exits(metadata, mocker, caplog):
+@mock.patch('shutil.which')
+def test_runner_run_exits(mocked_shutil_which, metadata, mocker, caplog):
     caplog.set_level(logging.WARNING)
     runner = runners.local_image.LocalImageTestRunner(metadata=metadata)
 
@@ -61,6 +65,7 @@ def test_runner_run_exits(metadata, mocker, caplog):
     mocker.patch.object(Build, 'get_container_engine')
     mocker.patch.object(runner, '_run_image')
     Build.get_container_engine.return_value = 'random_container_engine'
+    shutil.which.return_value = False
 
     runner.run()
 


### PR DESCRIPTION
Enables running `ansible-test` via Podman when setting the following in `galaxy-importer.cfg`:
```
RUN_ANSIBLE_TEST=True
ANSIBLE_TEST_LOCAL_IMAGE=True
LOCAL_IMAGE_DOCKER=False
```
Issue: AAH-5