### PR TITLE
setup.py: Allow greater version flexibility

### DIFF
--- a/CHANGES/185.feature
+++ b/CHANGES/185.feature
@@ -1,0 +1,1 @@
+Allow on to customize version for sdist building

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
+import os
 import setuptools
 
 from galaxy_importer import __version__
 
+version = os.environ.get("ALTERNATE_VERSION", __version__)
+
 setuptools.setup(
-    version=__version__,
+    version=version,
 )


### PR DESCRIPTION
This commit allows one to specify an alternative name for the build.

The goal of this commit is to allow nightly builds in the form of

```
ALTERNATE_VERSION = 0.2.1dev20201130gitb48b56e python setup.py sdist
```