### PR TITLE
Check collection metadata fields for maximum length

### DIFF
--- a/CHANGES/55.feature
+++ b/CHANGES/55.feature
@@ -1,0 +1,1 @@
+Check collection metadata fields for maximum length

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,5 +42,5 @@ galaxy_importer =
     ansible_test/build_template.yaml
 
 [coverage:report]
-fail_under = 94.1
+fail_under = 94.4
 precision = 2


### PR DESCRIPTION
- Add checks for max length of metadata fields, using pulp_ansible
  CollectionVersion model as reference
- Increase coverage fail_under value to match increased test coverage

Issue: AAH-55