### PR TITLE
Allow to install ansible(|-base|-core) separately

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ classifiers =
 packages = find:
 
 install_requires =
-    ansible
     ansible-lint>=5.0.0,<6.0
     attrs>=19.3.0,<21
     bleach>=3.3.0,<4
@@ -33,6 +32,15 @@ dev =
     pytest-cov>=2.8.1,<3
     pytest_mock>=2.0.0,<3
     towncrier
+
+ansible =
+    ansible
+
+ansible-core =
+    ansible-core
+
+ansible-base =
+    ansible-base
 
 [options.package_data]
 galaxy_importer =


### PR DESCRIPTION
Right now, galaxy-importer has a dependency on [ansible](https://pypi.org/project/ansible/), but in fact seems to be happy with any of ansible, ansible-core and ansible-base. Since pip does not allow to specify alternatives, my suggestion would be to drop the direct dependency on the ansible package, and allow to install ansible from extras. This is what ansible-lint is also doing since 5.0.0.