### PR TITLE
Use file_url from caller for remote storage

### DIFF
--- a/CHANGES/431.feature
+++ b/CHANGES/431.feature
@@ -1,0 +1,1 @@
+Use file_url from caller for remote storage

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,5 +41,5 @@ galaxy_importer =
     ansible_test/build_template.yaml
 
 [coverage:report]
-fail_under = 94.4
+fail_under = 94.2
 precision = 2

--- a/tests/unit/test_collection.py
+++ b/tests/unit/test_collection.py
@@ -363,7 +363,7 @@ def test__import_collection(mocker, tmp_collection_root, mock__import_collection
     mocker.patch.object(collection, 'subprocess')
     cfg = config.Config(config_data=config.ConfigFile.load())
     with open(os.path.join(tmp_collection_root, 'test_file.tar.gz'), 'w') as f:
-        collection._import_collection(file=f, filename='', logger=logging, cfg=cfg)
+        collection._import_collection(file=f, filename='', file_url=None, logger=logging, cfg=cfg)
     assert collection.subprocess.run.called
 
 


### PR DESCRIPTION
Use the file_url from caller to support additional
pulp backend storage platforms in addition to AWS
which is currently supported.

Issue: AAH-431