### PR TITLE
Update openshift job runner to use image with ansible-core 2.11

### DIFF
--- a/CHANGES/559.feature
+++ b/CHANGES/559.feature
@@ -1,0 +1,1 @@
+Update openshift job runner for ansible-test to use image with ansible-core 2.11

--- a/galaxy_importer/ansible_test/job_template.yaml
+++ b/galaxy_importer/ansible_test/job_template.yaml
@@ -12,7 +12,7 @@ spec:
       automountServiceAccountToken: false
       containers:
       - name: {job_name}
-        image: quay.io/cloudservices/automation-hub-ansible-test:a53df53
+        image: quay.io/cloudservices/automation-hub-ansible-test:1e3ff3b
         resources:
           requests:
             cpu: {cpu_request}


### PR DESCRIPTION
Issue: AAH-559

Uses image created from commit 1e3ff3b83ce0f547e5f7a5fa0253de0cdf7e84f2 on https://quay.io/repository/cloudservices/automation-hub-ansible-test?tab=tags