### PR TITLE
Remove ansible-core from dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ classifiers =
 packages = find:
 
 install_requires =
-    ansible-core
     ansible-lint>=5.0.8,<6.0
     attrs>=21.2.0,<22
     bleach>=3.3.0,<4


### PR DESCRIPTION
Remove ansible-core from dependencies to allow this script to
be used with older ansible versions - ansible, ansible-base, etc.
This dep is not used anyway.