### PR TITLE
Provide binary artifact and add sync_collection() interface

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8']
+        python-version: ['3.7', '3.8', '3.9']
 
     steps:
     - name: Checkout pull request HEAD commit instead of merge commit

--- a/CHANGES/979.feature
+++ b/CHANGES/979.feature
@@ -1,0 +1,1 @@
+Provide binary artifact and add sync_collection() interface

--- a/galaxy_importer/collection.py
+++ b/galaxy_importer/collection.py
@@ -89,9 +89,13 @@ def sync_collection(git_clone_path, output_path, logger=None, cfg=None):
     if not cfg:
         config_data = config.ConfigFile.load()
         cfg = config.Config(config_data=config_data)
-    logger.info(f"cfg={cfg}")
 
-    # TODO: override cfg so ansible_test does not run
+    cfg.run_ansible_test = False
+    cfg.run_ansible_lint = False
+    cfg.run_flake8 = False
+
+    # TODO: check peformance and how needed the docs_blob is for metadata sync
+    # cfg.run_ansible_doc = False
 
     filepath = _build_collection(git_clone_path, output_path, logger)
     with open(filepath, "rb") as fh:

--- a/galaxy_importer/collection.py
+++ b/galaxy_importer/collection.py
@@ -72,14 +72,17 @@ def import_collection(
     if git_clone_path:
         filepath = _build_collection(git_clone_path, output_path, logger)
         with open(filepath, "rb") as fh:
-            filename = os.path.basename(fh.name)  # TODO: useful to be passed as param?
-            metadata = _import_collection(fh, filename, file_url, logger, cfg)
+            # TODO: filename useful? may only be needed when user provides tarball artifact
+            filename = os.path.basename(fh.name)
+            metadata = _import_collection(
+                fh, filename, file_url=None, logger=logger, cfg=cfg
+            )
         return (metadata, filepath)
 
     return _import_collection(file, filename, file_url, logger, cfg)
 
 
-def sync_collection(git_clone_path=None, logger=None, cfg=None):
+def sync_collection(git_clone_path, output_path, logger=None, cfg=None):
     """Process collection metadata without linting to support pulp-ansible sync.
 
     Call _import_collection() with an overridden config to
@@ -94,10 +97,14 @@ def sync_collection(git_clone_path=None, logger=None, cfg=None):
 
     # TODO: override cfg so ansible_test does not run
 
-    file, filename = _build_collection(git_clone_path, logger)
-    metadata = _import_collection(file, filename, file_url=None, logger=logger, cfg=cfg)
-    return (metadata, file)
-    # TODO: accept user param ouput_path
+    filepath = _build_collection(git_clone_path, output_path, logger)
+    with open(filepath, "rb") as fh:
+        # TODO: filename useful? may only be needed for import_collection() calls
+        filename = os.path.basename(fh.name)
+        metadata = _import_collection(
+            fh, filename, file_url=None, logger=logger, cfg=cfg
+        )
+    return (metadata, filepath)
 
 
 def _build_collection(git_clone_path, output_path, logger=None):

--- a/galaxy_importer/collection.py
+++ b/galaxy_importer/collection.py
@@ -65,18 +65,14 @@ def import_collection(
     logger = logger or default_logger
 
     if (file and git_clone_path) or not (file or git_clone_path):
-        raise exc.ImporterError(
-            "Expected either 'file' or 'git_clone_path' to be populated"
-        )
+        raise exc.ImporterError("Expected either 'file' or 'git_clone_path' to be populated")
 
     if git_clone_path:
         filepath = _build_collection(git_clone_path, output_path, logger)
         with open(filepath, "rb") as fh:
             # TODO: filename useful? may only be needed when user provides tarball artifact
             filename = os.path.basename(fh.name)
-            metadata = _import_collection(
-                fh, filename, file_url=None, logger=logger, cfg=cfg
-            )
+            metadata = _import_collection(fh, filename, file_url=None, logger=logger, cfg=cfg)
         return (metadata, filepath)
 
     return _import_collection(file, filename, file_url, logger, cfg)
@@ -101,9 +97,7 @@ def sync_collection(git_clone_path, output_path, logger=None, cfg=None):
     with open(filepath, "rb") as fh:
         # TODO: filename useful? may only be needed for import_collection() calls
         filename = os.path.basename(fh.name)
-        metadata = _import_collection(
-            fh, filename, file_url=None, logger=logger, cfg=cfg
-        )
+        metadata = _import_collection(fh, filename, file_url=None, logger=logger, cfg=cfg)
     return (metadata, filepath)
 
 
@@ -113,13 +107,7 @@ def _build_collection(git_clone_path, output_path, logger=None):
     logger = logger or default_logger
     logger.info("Building collection tarball with ansible-galaxy collection build")
 
-    cmd = [
-        "ansible-galaxy",
-        "collection",
-        "build",
-        "--output-path",
-        output_path
-    ]
+    cmd = ["ansible-galaxy", "collection", "build", "--output-path", output_path]
     result = subprocess.run(cmd, cwd=git_clone_path, capture_output=True)
 
     if result.returncode != 0:
@@ -153,9 +141,7 @@ def _import_collection(file, filename, file_url, logger, cfg):
         if not os.path.exists(filepath):
             if not file_url:
                 # TODO(awcrosby): remove after using https://pulp.plan.io/issues/8486
-                parameters = {
-                    "ResponseContentDisposition": "attachment;filename=archive.tar.gz"
-                }
+                parameters = {"ResponseContentDisposition": "attachment;filename=archive.tar.gz"}
                 file_url = file.storage.url(file.name, parameters=parameters)
             filepath = _download_archive(file_url, tmp_dir)
 

--- a/galaxy_importer/collection.py
+++ b/galaxy_importer/collection.py
@@ -49,7 +49,7 @@ def import_collection(
     :param file: file handle of type BufferedReader.  # TODO: confirm same w/ pulp-ans caller
     :param filename: namedtuple of CollectionFilename.  # TODO: confirm same w/ pulp-ans caller
     :param file_url: .  # TODO: confirm w/ pulp-ans caller
-    :param git_clone_path: path to collection repo dir.  # TODO: should this just be dir to make generic?
+    :param git_clone_path: path to collection repo dir.  # TODO: make `dir` to be generic?
     :param output_path: path where collection build tarball file will be written
     :param logger: Optional logger instance.
     :param cfg: Optional config.
@@ -116,7 +116,11 @@ def _build_collection(git_clone_path, output_path, logger=None):
     result = subprocess.run(cmd, cwd=git_clone_path, capture_output=True)
 
     if result.returncode != 0:
-        raise exc.ImporterError("Error running `ansible-galaxy collection build`: {}".format(result.stderr.decode("utf-8").rstrip()))
+        raise exc.ImporterError(
+            "Error running `ansible-galaxy collection build`: {}".format(
+                result.stderr.decode("utf-8").rstrip()
+            )
+        )
 
     # TODO: use regex to get filename from stdout, compine with output_path
     stdout = result.stdout.decode("utf-8").rstrip()

--- a/galaxy_importer/collection.py
+++ b/galaxy_importer/collection.py
@@ -72,7 +72,6 @@ def import_collection(
         filepath = _build_collection(git_clone_path, output_path, logger)
         with open(filepath, "rb") as fh:
             metadata = _import_collection(fh, filename=None, file_url=None, logger=logger, cfg=cfg)
-            logger.info(f"filepath={filepath}")
         return (metadata, filepath)
 
     return _import_collection(file, filename, file_url, logger, cfg)

--- a/galaxy_importer/main.py
+++ b/galaxy_importer/main.py
@@ -91,6 +91,9 @@ def parse_args(args):
     return parser.parse_args(args=args)
 
 
+# TODO: add method to call sync_collection for testing
+
+
 def call_importer(args, cfg):
     """Returns result of galaxy_importer import process.
 

--- a/galaxy_importer/main.py
+++ b/galaxy_importer/main.py
@@ -91,13 +91,12 @@ def parse_args(args):
     return parser.parse_args(args=args)
 
 
-# TODO: add method to call sync_collection for testing
-
-
-def call_importer(args, cfg):
+def call_importer(args, cfg):  # pragma: no cover
     """Returns result of galaxy_importer import process.
 
     :param file: Artifact file to import.
+
+    Method excluded from pytest unit test coverage, tests exist in tests/integration
     """
     if not args.file:
         logger.info("No 'file' found")

--- a/galaxy_importer/main.py
+++ b/galaxy_importer/main.py
@@ -99,8 +99,6 @@ def call_importer(args, cfg):  # pragma: no cover
     Method excluded from pytest unit test coverage, tests exist in tests/integration
     """
     if not args.file:
-        logger.info("No 'file' found")
-
         return collection.import_collection(
             git_clone_path=os.path.abspath(args.git_clone_path),
             output_path=os.path.abspath(args.output_path),
@@ -108,11 +106,9 @@ def call_importer(args, cfg):  # pragma: no cover
             cfg=cfg,
         )
 
-    logger.info(args.file)
     match = FILENAME_REGEXP.match(os.path.basename(args.file))
     namespace, name, version = match.groups()
     filename = collection.CollectionFilename(namespace, name, version)
-    logger.info(filename)
 
     with open(args.file, "rb") as fh:
         try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
 [options.extras_require]
 dev =
     black>=21.7b0
+    GitPython>=3.1.24
     pyfakefs>=4.4.0,<5
     pytest>=6.2.4,<7
     pytest-cov>=2.11.1,<3

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
 [options.extras_require]
 dev =
     black>=21.7b0
-    GitPython>=3.1.24
+    GitPython>=3.1.20
     pyfakefs>=4.4.0,<5
     pytest>=6.2.4,<7
     pytest-cov>=2.11.1,<3

--- a/tests/integration/run_importer.sh
+++ b/tests/integration/run_importer.sh
@@ -38,8 +38,13 @@ export GALAXY_IMPORTER_CONFIG=galaxy-importer.cfg
 echo "Using galaxy-importer.cfg:"
 cat galaxy-importer.cfg
 
-# run the importer
+# run the importer with file artifact tarball
 python3 -m galaxy_importer.main foo/bar/foo-bar-*.tar.gz
+RETURN_CODE=$?
+
+# run the importer with git_clone_path and output_path
+rm foo/bar/foo-bar-*.tar.gz
+python3 -m galaxy_importer.main --git-clone-path=foo/bar/ --output-path=foo/bar/
 RETURN_CODE=$?
 
 # cleanup

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -29,11 +29,12 @@ def test_parser():
     assert parser.file == "my_file.tar.gz"
     assert parser.print_result
 
-    # SystemExit with missing required positional file argument
-    with pytest.raises(SystemExit):
-        main.parse_args(["--print-result"])
+    parser = main.parse_args(["--git-clone-path=/my/clone/path", "--output-path=/my/output/path"])
+    assert not parser.file
+    assert parser.git_clone_path == "/my/clone/path"
+    assert parser.output_path == "/my/output/path"
 
 
 def test_main_no_args():
-    with pytest.raises(SystemExit):
+    with pytest.raises(TypeError, match="expected str, bytes or os.PathLike object, not NoneType"):
         main.main(args={})


### PR DESCRIPTION
* Provide a binary artifact when import_collection() called using a git_clone_path
* Add sync_collection() interface to return metadata without linting, to
  support pulp-ansible sync

Issue: AAH-979