### PR TITLE
ansible-lint: Allow to install lint 6.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.8', '3.9']
 
     steps:
     - name: Checkout pull request HEAD commit instead of merge commit

--- a/CHANGES/1429.misc
+++ b/CHANGES/1429.misc
@@ -1,0 +1,1 @@
+Allow galaxy-importer to pull ansible-lint 6

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ packages = find:
 install_requires =
     ansible-core
     ansible-builder>=1.0.1,<2.0
-    ansible-lint>=5.0.8,<6.0
+    ansible-lint>=5.0.8,<7.0
     attrs>=21.2.0,<22
     bleach>=3.3.0,<4
     bleach-allowlist>=1.0.3,<2


### PR DESCRIPTION
Currently galaxy-importer limit ansible-lint to version previous to
ansible-lint 6. Given the ansible-lint team released a 6.0.0 few weeks
ago this aims to ensure it can be used.

Issue: AAH-1429