### PR TITLE
Fix build of ansible-test image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
     - name: Checkout pull request HEAD commit instead of merge commit

--- a/galaxy_importer/ansible_test/container/Dockerfile
+++ b/galaxy_importer/ansible_test/container/Dockerfile
@@ -17,7 +17,7 @@ RUN useradd user1 \
     python2.7 -m pip install virtualenv==16.7.12 --disable-pip-version-check && \
     # On updating ansible-core version, update the FROM statement to the matching base-test-container version
     # After quay image is built, tag should be updated in ansible_test/job_template.yaml
-    python3.9 -m pip install ansible-core==2.12.0 --disable-pip-version-check && \
+    python3.9 -m pip install ansible-core==2.12.3 --disable-pip-version-check && \
     # Creates dir with correct permissions for where ansible-test sanity writes files, needed for non-privileged containers
     mkdir -m 0775 /.pylint.d
 


### PR DESCRIPTION
The build of the `ansible-test` image is breaking. This updates `ansible-core` to a version where it is fixed with the base image `base-test-container`