### PR TITLE
ansible-lint: Allow to install lint 6.0.0

### DIFF
--- a/CHANGES/1429.misc
+++ b/CHANGES/1429.misc
@@ -1,0 +1,1 @@
+Allow galaxy-importer to pull ansible-lint 6

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ packages = find:
 install_requires =
     ansible-core
     ansible-builder>=1.0.1,<2.0
-    ansible-lint>=5.0.8,<6.0
+    ansible-lint>=5.0.8,<7.0
     attrs>=21.2.0,<22
     bleach>=3.3.0,<4
     bleach-allowlist>=1.0.3,<2

--- a/tests/unit/test_loader_content.py
+++ b/tests/unit/test_loader_content.py
@@ -240,7 +240,7 @@ def test_flake8_output(mocked_popen, loader_module):
 ANSIBLELINT_TASK_OK = """---
 - name: Add mongodb repo apt_key
   become: true
-  apt_key: keyserver=hkp
+  ansible.builtin.apt_key: keyserver=hkp
   until: result.rc == 0
 """
 
@@ -248,14 +248,14 @@ ANSIBLELINT_PLAYBOOK_WARN = """---
 - hosts: all
   tasks:
     - name: edit vimrc
-      lineinfile:
+      ansible.builtin.lineinfile:
         path: /etc/vimrc
         line: "{{var_spacing_problem}}"
 """
 
 ANSIBLELINT_TASK_WARN = """---
 - name: edit vimrc
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: /etc/vimrc
     line: "{{var_spacing_problem}}"
 """


### PR DESCRIPTION
Currently galaxy-importer limit ansible-lint to version previous to
ansible-lint 6. Given the ansible-lint team released a 6.0.0 few weeks
ago this aims to ensure it can be used.

Issue: AAH-1429