### PR TITLE
'requires_ansible' does not need to be semver

### DIFF
--- a/CHANGES/981.bugfix
+++ b/CHANGES/981.bugfix
@@ -1,0 +1,1 @@
+Change 'requires_ansible' to use custom ansible ver spec instead of semver

--- a/galaxy_importer/loaders/runtime_file.py
+++ b/galaxy_importer/loaders/runtime_file.py
@@ -17,11 +17,11 @@
 
 import logging
 import os
-import semantic_version
 import yaml
 
 from galaxy_importer import constants
 from galaxy_importer import exceptions as exc
+from galaxy_importer.utils import requires_ansible_version
 
 default_logger = logging.getLogger(__name__)
 
@@ -61,9 +61,9 @@ class RuntimeFileLoader:
                 f"{constants.MAX_LENGTH_REQUIRES_ANSIBLE} characters"
             )
         try:
-            semantic_version.SimpleSpec(requires_ansible)
+            requires_ansible_version.validate(requires_ansible)
             return requires_ansible
         except ValueError:
             raise exc.RuntimeFileError(
-                "'requires_ansible' is not a valid semantic_version requirement specification"
+                "'requires_ansible' is not a valid requirement specification"
             )

--- a/galaxy_importer/utils/requires_ansible_version.py
+++ b/galaxy_importer/utils/requires_ansible_version.py
@@ -1,0 +1,17 @@
+from packaging.specifiers import SpecifierSet
+
+
+def validate(requirement_string):
+    """Validate requires_ansible specifier
+
+    Args:
+        requirement_string (str): The value of the 'requires_ansible' attribute in the runtime file.
+    Raises:
+        InvalidSpecifier: If the value of requirement_string is not a
+            valid packaging.specifiers.SpecifierSet.
+
+    Returns:
+        bool: True if requirement_string is valid, otherwise should raise exception.
+    """
+    SpecifierSet(requirement_string)
+    return True

--- a/tests/unit/test_loader_runtime_file.py
+++ b/tests/unit/test_loader_runtime_file.py
@@ -39,7 +39,7 @@ BAD_YAML = "requires_ansible: : : : : '>=2.9.10,<2.11.5'"
 
 TOO_LONG_REQUIRES_ANSIBLE = "requires_ansible: '>=" + "2" * 256 + "'"
 
-BAD_VERSION_SPEC = "requires_ansible: '>=2,<=3,,,'"
+BAD_VERSION_SPEC = "requires_ansible: '37'"
 
 
 def test_no_runtime_file(tmpdir):
@@ -93,7 +93,7 @@ def test_bad_version_spec(tmpdir):
     tmpdir.mkdir("meta").join("runtime.yml").write(BAD_VERSION_SPEC)
     with pytest.raises(
         exc.RuntimeFileError,
-        match="not a valid semantic_version requirement specification",
+        match="not a valid requirement specification",
     ):
         loader = loaders.RuntimeFileLoader(collection_path=tmpdir)
         loader.get_requires_ansible()

--- a/tests/unit/test_utils_requires_ansible_version.py
+++ b/tests/unit/test_utils_requires_ansible_version.py
@@ -1,0 +1,33 @@
+# (c) 2012-2022, Ansible by Red Hat
+#
+# This file is part of Ansible Galaxy
+#
+# Ansible Galaxy is free software: you can redistribute it and/or modify
+# it under the terms of the Apache License as published by
+# the Apache Software Foundation, either version 2 of the License, or
+# (at your option) any later version.
+#
+# Ansible Galaxy is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# Apache License for more details.
+#
+# You should have received a copy of the Apache License
+# along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
+
+import pytest
+from packaging.specifiers import InvalidSpecifier
+
+from galaxy_importer.utils import requires_ansible_version
+
+
+def test_invalid_specifier():
+    bad_spec = "37"
+    with pytest.raises(InvalidSpecifier):
+        requires_ansible_version.validate(bad_spec)
+
+
+def test_valid_specifier():
+    spec = "<2.0"
+    result = requires_ansible_version.validate(spec)
+    assert result is True, "%s should be a valid requires_ansible specifier but is not" % spec


### PR DESCRIPTION
Import was checking if the requires_ansible field was
valid semver. But the format used by ansible for versioning
is not valid semver.

Instead it is based on pythons builting
packagaging.specifiers.Specifier and SpecifierSet

This changes replaces the validation of 'requires_ansible'
with one based on SpecifierSet.

Issue: AAH-981