### PR TITLE
Add PSF-2.0 license (https://spdx.org/licenses/PSF-2.0)

### DIFF
--- a/galaxy_importer/utils/spdx_licenses.json
+++ b/galaxy_importer/utils/spdx_licenses.json
@@ -893,6 +893,9 @@
     "PHP-3.01":{
         "deprecated":false
     },
+    "PSF-2.0":{
+        "deprecated":false
+    },
     "Parity-6.0.0":{
         "deprecated":false
     },


### PR DESCRIPTION
This is used in quite a few collections, and in ansible-core as well (often due to the vendored `LooseVersion` / `StrictVersion` code). See for example https://github.com/ansible/ansible/blob/devel/licenses/PSF-license.txt or https://github.com/ansible-collections/community.crypto/blob/main/PSF-license.txt.