### PR TITLE
Update ansible-test base image and ansible-core

### DIFF
--- a/CHANGES/1742.misc
+++ b/CHANGES/1742.misc
@@ -1,0 +1,1 @@
+Update ansible-test base image and ansible-core

--- a/galaxy_importer/ansible_test/container/Dockerfile
+++ b/galaxy_importer/ansible_test/container/Dockerfile
@@ -12,9 +12,6 @@ RUN useradd user1 \
     mkdir -m 0775 /archive && \
     mkdir -p -m 0775 /ansible_collections /ansible_collections/ns /ansible_collections/ns/col && \
     touch /ansible_collections/ns/col/placeholder.txt && \
-    # Sets up python2 env since running from base-test-container not default-test-container
-    python2.6 -m pip.__main__ install virtualenv==15.2.0 --index https://d2c8fqinjk13kw.cloudfront.net/simple/ --disable-pip-version-check && \
-    python2.7 -m pip install virtualenv==16.7.12 --disable-pip-version-check && \
     # On updating ansible-core version, update the FROM statement to the matching base-test-container version
     python3.9 -m pip install ansible-core==2.13.2 --disable-pip-version-check && \
     # Creates dir with correct permissions for where ansible-test sanity writes files, needed for non-privileged containers

--- a/galaxy_importer/ansible_test/container/Dockerfile
+++ b/galaxy_importer/ansible_test/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ansible/base-test-container:1.1.0
+FROM quay.io/ansible/base-test-container:2.2.0
 
 COPY entrypoint.sh /entrypoint
 
@@ -16,8 +16,7 @@ RUN useradd user1 \
     python2.6 -m pip.__main__ install virtualenv==15.2.0 --index https://d2c8fqinjk13kw.cloudfront.net/simple/ --disable-pip-version-check && \
     python2.7 -m pip install virtualenv==16.7.12 --disable-pip-version-check && \
     # On updating ansible-core version, update the FROM statement to the matching base-test-container version
-    # After quay image is built, tag should be updated in ansible_test/job_template.yaml
-    python3.9 -m pip install ansible-core==2.12.3 --disable-pip-version-check && \
+    python3.9 -m pip install ansible-core==2.13.2 --disable-pip-version-check && \
     # Creates dir with correct permissions for where ansible-test sanity writes files, needed for non-privileged containers
     mkdir -m 0775 /.pylint.d
 


### PR DESCRIPTION
Update `ansible-core` to 2.13.2 https://github.com/ansible/ansible/commit/0863427230c79030573568eb9532725cf712450b and update `quay.io/ansible/base-test-container` version to match https://github.com/ansible/ansible/blob/0863427230c79030573568eb9532725cf712450b/test/lib/ansible_test/_data/completion/docker.txt

Issue: AAH-1742