### PR TITLE
Upgrade all pkg in ansible-test img on each build

### DIFF
--- a/CHANGES/1951.misc
+++ b/CHANGES/1951.misc
@@ -1,0 +1,1 @@
+Upgrade all pkg in ansible-test img on each build

--- a/galaxy_importer/ansible_test/container/Dockerfile
+++ b/galaxy_importer/ansible_test/container/Dockerfile
@@ -7,6 +7,9 @@ RUN useradd user1 \
       --no-create-home \
       --gid root && \
     apt-get update -y && \
+    # upgrade all packages except python, as they can conflict with python setup in base image
+    apt-mark hold python* && \
+    apt-get upgrade -y && \
     apt-get install -y wget && \
     chmod +x /entrypoint && \
     mkdir -m 0775 /archive && \


### PR DESCRIPTION
Allow for getting os package upgrades before they are incorporated into
the base images.

Issue: [AAH-1951](https://issues.redhat.com/browse/AAH-1951)