### PR TITLE
Limit ansible-lint max version to <6.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ packages = find:
 install_requires =
     ansible-core
     ansible-builder>=1.0.1,<2.0
-    ansible-lint>=6.2.2,<7.0
+    ansible-lint>=6.7.0,<6.8
     attrs>=21.2.0,<22
     bleach>=3.3.0,<4
     bleach-allowlist>=1.0.3,<2


### PR DESCRIPTION
Due to https://github.com/ansible/ansible-lint/issues/2628

No-Issue