### PR TITLE
Fixes to work with ansible-lint 6.8

### DIFF
--- a/galaxy_importer/loaders/content.py
+++ b/galaxy_importer/loaders/content.py
@@ -212,9 +212,11 @@ class RoleLoader(ContentLoader):
             f"ANSIBLE_LOCAL_TEMP={self.cfg.ansible_local_tmp}",
             "ansible-lint",
             path,
-            "-p",
-            "-x",
+            "--parseable",
+            "--skip-list",
             "metadata",
+            "--project-dir",
+            os.path.dirname(path),
         ]
         self.log.debug("CMD: " + " ".join(cmd))
         proc = Popen(

--- a/tests/unit/test_loader_content.py
+++ b/tests/unit/test_loader_content.py
@@ -240,7 +240,8 @@ def test_flake8_output(mocked_popen, loader_module):
 ANSIBLELINT_TASK_OK = """---
 - name: Add mongodb repo apt_key
   become: true
-  ansible.builtin.apt_key: keyserver=hkp
+  ansible.builtin.apt_key:
+    keyserver: hkp
   until: result.rc == 0
 """
 


### PR DESCRIPTION
* Add project-dir param when calling ansible-lint
* Remove free-form syntax in test

No-Issue