### PR TITLE
Expanding changelog check to include more possible changelog types

### DIFF
--- a/CHANGES/2086.feature
+++ b/CHANGES/2086.feature
@@ -1,0 +1,1 @@
+Modifying the certification changelog check to also check for changelogs under `CHANGELOG.md` and `changelogs/changelog.yaml`.

--- a/galaxy_importer/loaders/collection.py
+++ b/galaxy_importer/loaders/collection.py
@@ -118,11 +118,16 @@ class CollectionLoader(object):
 
     def _check_collection_changelog(self):
         """Log an error when a CHANGELOG file is not present in the root of the collection."""
-        CHANGELOG_ERROR = "CHANGELOG.rst file not found at top level of collection."
+        CHANGELOG_ERROR = "A changelog file was not found in the collection. \
+            Please add a CHANGELOG.rst, CHANGELOG.md, or changelogs/changelog.yaml file."
 
-        changelog_path = os.path.join(self.path, "CHANGELOG.rst")
+        changelog_rst_path = os.path.join(self.path, "CHANGELOG.rst")
+        changelog_md_path = os.path.join(self.path, "CHANGELOG.md")
+        changelog_yaml_path = os.path.join(self.path, "changelogs/changelog.yaml")
 
-        if not os.path.exists(changelog_path):
+        if not os.path.exists(changelog_rst_path) \
+            and not os.path.exists(changelog_md_path) \
+            and not os.path.exists(changelog_yaml_path):
             self.log.error(CHANGELOG_ERROR)
 
     def _check_ee_yml_dep_files(self):  # pragma: no cover

--- a/galaxy_importer/loaders/collection.py
+++ b/galaxy_importer/loaders/collection.py
@@ -118,16 +118,20 @@ class CollectionLoader(object):
 
     def _check_collection_changelog(self):
         """Log an error when a CHANGELOG file is not present in the root of the collection."""
-        CHANGELOG_ERROR = "A changelog file was not found in the collection. \
-            Please add a CHANGELOG.rst, CHANGELOG.md, or changelogs/changelog.yaml file."
+        CHANGELOG_ERROR = (
+            "No changelog found. "
+            "Add a CHANGELOG.rst, CHANGELOG.md, or changelogs/changelog.yaml file."
+        )
 
         changelog_rst_path = os.path.join(self.path, "CHANGELOG.rst")
         changelog_md_path = os.path.join(self.path, "CHANGELOG.md")
         changelog_yaml_path = os.path.join(self.path, "changelogs/changelog.yaml")
 
-        if not os.path.exists(changelog_rst_path) \
-            and not os.path.exists(changelog_md_path) \
-            and not os.path.exists(changelog_yaml_path):
+        if (
+            not os.path.exists(changelog_rst_path)
+            and not os.path.exists(changelog_md_path)
+            and not os.path.exists(changelog_yaml_path)
+        ):
             self.log.error(CHANGELOG_ERROR)
 
     def _check_ee_yml_dep_files(self):  # pragma: no cover

--- a/tests/unit/test_loader_collection.py
+++ b/tests/unit/test_loader_collection.py
@@ -432,13 +432,14 @@ def test_missing_readme(populated_collection_root):
 @mock.patch("galaxy_importer.collection.CollectionLoader._build_docs_blob")
 def test_changelog_fail(_build_docs_blob, populated_collection_root, caplog):
     _build_docs_blob.return_value = {}
-
+    
     CollectionLoader(
         populated_collection_root,
         filename=None,
         cfg=SimpleNamespace(run_ansible_doc=True),
     ).load()
-    assert "CHANGELOG.rst file not found at top level of collection." in str(caplog.records[0])
+    assert "A changelog file was not found in the collection. \
+            Please add a CHANGELOG.rst, CHANGELOG.md, or changelogs/changelog.yaml file." in str(caplog.records[0])
 
 
 def test_manifest_json_with_no_files_json_info(populated_collection_root):

--- a/tests/unit/test_loader_collection.py
+++ b/tests/unit/test_loader_collection.py
@@ -432,14 +432,17 @@ def test_missing_readme(populated_collection_root):
 @mock.patch("galaxy_importer.collection.CollectionLoader._build_docs_blob")
 def test_changelog_fail(_build_docs_blob, populated_collection_root, caplog):
     _build_docs_blob.return_value = {}
-    
+
     CollectionLoader(
         populated_collection_root,
         filename=None,
         cfg=SimpleNamespace(run_ansible_doc=True),
     ).load()
-    assert "A changelog file was not found in the collection. \
-            Please add a CHANGELOG.rst, CHANGELOG.md, or changelogs/changelog.yaml file." in str(caplog.records[0])
+    assert (
+        "No changelog found. "
+        "Add a CHANGELOG.rst, CHANGELOG.md, or changelogs/changelog.yaml file."
+        in str(caplog.records[0])
+    )
 
 
 def test_manifest_json_with_no_files_json_info(populated_collection_root):


### PR DESCRIPTION
Community has updated their changelog requirements for a collection's inclusion in the community package. https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst#changelogs

PE is aligning the certification changelog requirement with this community requirement. 

This change expands the possible locations of a collection's changelog from just `<root>/CHANGELOG.rst` to two others, listed below. The check_collection_changelog function now checks for the following changelog files:
`<root>/CHANGELOG.md`
`<root>/CHANGELOG.rst`
`<root>/changelogs/changelog.yaml`

This also brings galaxy-importer into alignment with this rule implemented in ansible-lint. See: https://github.com/ansible/ansible-lint/pull/2832


Issue: AAH-2086