### PR TITLE
Add tox configuration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,6 @@
 [flake8]
 exclude =
+    ./.tox/*,
     ./galaxy_importer.egg-info/*,
     ./build/*,
     ./dist/*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,20 +32,15 @@ jobs:
 
     - name: Install source package and dependencies
       run: |
-        python -m pip install -e .[dev]
+        python -m pip install tox
 
     - name: Run linting
       run: |
-        make lint
+        tox -e lint
 
-    - name: Run unit tests
+    - name: Run tests
       run: |
-        make test/unit
-
-    - name: Run functional tests
-      run: |
-        make test/functional
-
+        tox -e py
 
   publish:
     name: Build and publish to PyPI registry

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dist/
 
 # Environments
 .env
+.tox

--- a/galaxy_importer/schema.py
+++ b/galaxy_importer/schema.py
@@ -65,7 +65,6 @@ _FILENAME_RE = re.compile(
 
 @attr.s(slots=True)
 class CollectionFilename(object):
-
     namespace = attr.ib()
     name = attr.ib()
     version = attr.ib(converter=semantic_version.Version)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
+[tool.pytest.ini_options]
+markers = [
+    "sha256",
+]
+
 [tool.towncrier]
     package = "galaxy_importer"
     directory = "CHANGES/"

--- a/tests/unit/test_loader_collection.py
+++ b/tests/unit/test_loader_collection.py
@@ -451,7 +451,6 @@ def test_manifest_json_with_no_files_json_info(populated_collection_root):
     # MANIFEST.json did not contain a 'file_manifest_file' item pointing to FILES.json
     msg_match = "MANIFEST.json did not contain a 'file_manifest_file' item pointing to FILES.json"
     with pytest.raises(exc.ManifestValidationError, match=msg_match) as excinfo:
-
         CollectionLoader(populated_collection_root, filename=None).load()
 
     # pytest.raises ensures the outer exeption is a ManifestValidationError, this

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+minversion = 4.0.0
+envlist =
+    lint
+    py
+
+[testenv]
+description = Run unit tests
+usedevelop = True
+extras = dev
+commands =
+    pytest tests/unit tests/functional --cov=galaxy_importer --cov-branch
+passenv =
+    *
+
+[testenv:lint]
+description = Run linters
+commands =
+    black . --extend-exclude .github/ --line-length 100 --check
+    flake8


### PR DESCRIPTION
This change should make local testing much easier, especially with different versions of python. Tox also documents (`tox -l`) all possible commands with descriptions, something that the Makefile never supported.

No-Issue