### PR TITLE
Avoid pytest warning about undeclared marker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
+[tool.pytest.ini_options]
+markers = [
+    "sha256",
+]
+
 [tool.towncrier]
     package = "galaxy_importer"
     directory = "CHANGES/"


### PR DESCRIPTION
Avoids multiple warnings during testing such:
PytestUnknownMarkWarning: Unknown pytest.mark.sha256 - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/mark.html

No-Issue
