### PR TITLE
Remove ceiling from dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Install source package and dependencies
       run: |
-        python -m pip install -e .[dev]
+        python -m pip install -e '.[dev,lock]'
 
     - name: Run linting
       run: |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Clone repo and go into project directory
 
 Install into environment the local setup.py including its development dependencies:
 
-`pip install -e .[dev]`
+`pip install -e .[dev,lock]`
 
 ### Run importer
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,16 +18,16 @@ packages = find:
 
 install_requires =
     ansible-core
-    ansible-builder>=1.0.1,<2.0
-    ansible-lint>=6.2.2,<7.0
-    attrs>=21.2.0,<22
-    bleach>=3.3.0,<4
-    bleach-allowlist>=1.0.3,<2
-    flake8>=3.9.2,<4
-    markdown>=3.3.4,<4
-    pyyaml>=5.4.1,<6
-    requests>=2.25.1,<3
-    semantic_version>=2.8.5,<3
+    ansible-builder>=1.0.1
+    ansible-lint>=6.2.2
+    attrs>=21.2.0
+    bleach>=3.3.0
+    bleach-allowlist>=1.0.3
+    flake8>=3.9.2
+    markdown>=3.3.4
+    pyyaml>=5.4.1
+    requests>=2.25.1
+    semantic_version>=2.8.5
 
 [options.extras_require]
 dev =
@@ -38,6 +38,18 @@ dev =
     pytest-cov>=2.11.1,<3
     pytest_mock>=3.6.1,<4
     towncrier
+# For internal use only
+lock =
+    ansible-builder>=1.0.1,<2.0
+    ansible-lint>=6.2.2,<7.0
+    attrs>=21.2.0,<22
+    bleach>=3.3.0,<4
+    bleach-allowlist>=1.0.3,<2
+    flake8>=3.9.2,<4
+    markdown>=3.3.4,<4
+    pyyaml>=5.4.1,<6
+    requests>=2.25.1,<3
+    semantic_version>=2.8.5,<3
 
 [options.package_data]
 galaxy_importer =


### PR DESCRIPTION
- removes ceiling from dependencies, which basically are armed time-bombs
- adds a "lock" extra which includes the old ceilings, so this could
  be used by consumers more afraid of new libraries
- Fixes blocking issue affecting https://github.com/ansible/ansible-lint/issues/2874
