### PR TITLE
add support for parsing filter-type plugins via yaml files

### DIFF
--- a/galaxy_importer/constants.py
+++ b/galaxy_importer/constants.py
@@ -31,6 +31,8 @@ ANSIBLE_DOC_SUPPORTED_TYPES = [
     "module",
     "strategy",
     "vars",
+    "filter",
+    "test",
 ]
 ANSIBLE_DOC_PLUGIN_MAP = {"module": "modules"}
 ANSIBLE_DOC_KEYS = ["doc", "metadata", "examples", "return"]

--- a/galaxy_importer/finder.py
+++ b/galaxy_importer/finder.py
@@ -66,8 +66,15 @@ class ContentFinder(object):
         """Find all python files anywhere inside content_dir."""
         for path, _, files in os.walk(content_dir):
             for file in files:
-                if not file.endswith(".py") or file == "__init__.py":
-                    continue
+                if content_type in [
+                    constants.ContentType.FILTER_PLUGIN,
+                    constants.ContentType.TEST_PLUGIN,
+                ]:
+                    if not (file.endswith(".yml") or file.endswith(".yaml")):
+                        continue
+                else:
+                    if not file.endswith(".py") or file == "__init__.py":
+                        continue
                 file_path = os.path.join(path, file)
                 rel_path = os.path.relpath(file_path, self.path)
                 yield Result(content_type, rel_path)

--- a/tests/unit/test_loader_doc_string.py
+++ b/tests/unit/test_loader_doc_string.py
@@ -42,13 +42,13 @@ def test_get_plugins(doc_string_loader, tmpdir):
     tmpdir.join("__init__.py").write("")
     tmpdir.join("should_be_ignored.txt").write("")
     tmpdir.join("my_module.py").write("")
-    plugins = doc_string_loader._get_plugins(str(tmpdir))
+    plugins = doc_string_loader._get_plugins(str(tmpdir), "dummy")
     assert plugins == ["my_namespace.my_collection.my_module"]
 
 
 def test_get_plugins_subdirs(doc_string_loader, tmpdir):
     tmpdir.mkdir("subdir1").mkdir("subdir2").join("nested_plugin.py").write("")
-    plugins = doc_string_loader._get_plugins(str(tmpdir))
+    plugins = doc_string_loader._get_plugins(str(tmpdir), "dummy")
     assert plugins == ["my_namespace.my_collection.subdir1.subdir2.nested_plugin"]
 
 


### PR DESCRIPTION
Hi,

I thought it'd be useful to fetch the filter plugin documentation as well.
Since filter files have no documentation blocks the documentation is stored in yaml files matching the filter name. This patch makes the importer read these yamls instead of python files when handling filter plugins.
