### PR TITLE
Enable EDA Testing - linters in `tox`

### DIFF
--- a/CHANGES/2307.feature
+++ b/CHANGES/2307.feature
@@ -1,0 +1,1 @@
+Adding EDA testing with `tox`, containing the `ruff`, `darglint`, and `pylint` linters. 

--- a/galaxy_importer/ansible_test/builders/local_image_build.py
+++ b/galaxy_importer/ansible_test/builders/local_image_build.py
@@ -94,7 +94,12 @@ class Build(object):
         pkg_entrypoint = pkg_resources.resource_filename(
             "galaxy_importer", "ansible_test/container/entrypoint.sh"
         )
+        eda_linting = pkg_resources.resource_filename(
+            "galaxy_importer", "ansible_test/container/eda/tox.ini"
+        )
         shutil.copyfile(pkg_entrypoint, os.path.join(dir, "entrypoint.sh"))
+        os.mkdir(os.path.join(dir, "eda"))
+        shutil.copyfile(eda_linting, os.path.join(dir, "eda", "tox.ini"))
 
         cmd = [container_engine, "build", ".", "--quiet"]
         proc = Popen(

--- a/galaxy_importer/ansible_test/container/Dockerfile
+++ b/galaxy_importer/ansible_test/container/Dockerfile
@@ -17,8 +17,12 @@ RUN useradd user1 \
     touch /ansible_collections/ns/col/placeholder.txt && \
     # On updating ansible-core version, update the FROM statement to the matching base-test-container version
     python3.9 -m pip install ansible-core==2.14.1 --disable-pip-version-check && \
+    python3.9 -m pip install tox && \
     # Creates dir with correct permissions for where ansible-test sanity writes files, needed for non-privileged containers
-    mkdir -m 0775 -p /.cache/pylint
+    mkdir -m 0775 -p /.cache/pylint && \
+    mkdir -m 0775 -p /eda /eda/tox
+
+COPY eda/tox.ini /eda/tox
 
 ENV HOME /
 

--- a/galaxy_importer/ansible_test/container/eda/tox.ini
+++ b/galaxy_importer/ansible_test/container/eda/tox.ini
@@ -1,0 +1,25 @@
+[tox]
+envlist = ruff, darglint
+requires = 
+    ruff
+    darglint
+    pylint
+
+
+[testenv:ruff]
+deps = ruff
+commands = - ruff check --select ALL --ignore INP001 -q {posargs}/extensions/eda/plugins
+
+
+[testenv:darglint]
+deps = darglint
+commands = - darglint -s numpy -z full {posargs}/extensions/eda/plugins
+
+
+[testenv:pylint-event-source]
+deps = pylint
+commands = - pylint {posargs}/extensions/eda/plugins/event_source/*.py --output-format=parseable -sn --disable R0801
+
+[testenv:pylint-event-filter]
+deps = pylint
+commands = - pylint {posargs}/extensions/eda/plugins/event_filter/*.py --output-format=parseable -sn --disable R0801

--- a/galaxy_importer/ansible_test/container/eda/tox.ini
+++ b/galaxy_importer/ansible_test/container/eda/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = ruff, darglint
 requires = 
     ruff
     darglint

--- a/galaxy_importer/ansible_test/container/entrypoint.sh
+++ b/galaxy_importer/ansible_test/container/entrypoint.sh
@@ -42,7 +42,10 @@ EOF
 popd > /dev/null
 mv placeholder_namespace/placeholder_name placeholder_namespace/"$NAME"
 mv placeholder_namespace/ "$NAMESPACE"
-cd /ansible_collections/"$NAMESPACE"/"$NAME"
+
+COLLECTION_DIR=/ansible_collections/"$NAMESPACE"/"$NAME"
+
+cd $COLLECTION_DIR
 
 # Set env var so ansible --version does not error with getpass.getuser()
 export USER=user1
@@ -59,24 +62,24 @@ ansible-test sanity --skip-test import --skip-test validate-modules --skip-test 
 
 echo "ansible-test sanity complete."
 
-EDA_PLUGIN_DIR=/ansible_collections/"$NAMESPACE"/"$NAME"/extensions/eda/plugins
-EDA_PLUGIN_SOURCE=/ansible_collections/"$NAMESPACE"/"$NAME"/extensions/eda/plugins/event_source
-EDA_PLUGIN_FILTER=/ansible_collections/"$NAMESPACE"/"$NAME"/extensions/eda/plugins/event_filter
+EDA_PLUGIN_DIR=$COLLECTION_DIR/extensions/eda/plugins
+EDA_PLUGIN_SOURCE=$COLLECTION_DIR/extensions/eda/plugins/event_source
+EDA_PLUGIN_FILTER=$COLLECTION_DIR/extensions/eda/plugins/event_filter
 
 
 if [ -d "$EDA_PLUGIN_DIR" ]
 then
     echo "EDA plugin content found. Running ruff on /extensions/eda/plugins..."
     cd /eda/tox
-    tox -q -e ruff -- /ansible_collections/"$NAMESPACE"/"$NAME"
+    tox -q -e ruff -- $COLLECTION_DIR
 
     echo "Running darglint on /extensions/eda/plugins..."
-    tox -q -e darglint -- /ansible_collections/"$NAMESPACE"/"$NAME"
+    tox -q -e darglint -- $COLLECTION_DIR
 
     if [ -d "$EDA_PLUGIN_SOURCE" ]
     then
         echo "Running pylint on /extensions/eda/plugins/event_source..."
-        tox -e pylint-event-source -q -- /ansible_collections/"$NAMESPACE"/"$NAME"
+        tox -e pylint-event-source -q -- $COLLECTION_DIR
     else
         echo "No EDA event_source plugins found. Skipping pylint on /extensions/eda/plugins/event_source."
     fi
@@ -84,9 +87,9 @@ then
     if [ -d "$EDA_PLUGIN_FILTER" ]
     then
         echo "Running pylint on /extensions/eda/plugins/event_filter..."
-        tox -e pylint-event-filter -q -- /ansible_collections/"$NAMESPACE"/"$NAME"
+        tox -e pylint-event-filter -q -- $COLLECTION_DIR
     else
-        echo "No EDA event_filter plugins found."
+        echo "No EDA event_filter plugins found. Skipping pylint on /extensions/eda/plugins/event_filter."
     fi
     echo "EDA linting complete."
 

--- a/galaxy_importer/ansible_test/container/entrypoint.sh
+++ b/galaxy_importer/ansible_test/container/entrypoint.sh
@@ -87,9 +87,10 @@ then
         tox -e pylint-event-filter -q -- /ansible_collections/"$NAMESPACE"/"$NAME"
     else
         echo "No EDA event_filter plugins found."
-    fi 
+    fi
+    echo "EDA linting complete."
 
 else
     echo "No EDA content found. Skipping linters."
 fi
-echo "EDA linting complete."
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,8 @@ galaxy_importer =
     ansible_test/job_template.yaml
     ansible_test/container/Dockerfile
     ansible_test/container/entrypoint.sh
+    ansible_test/container/eda/tox.ini
+
 
 [coverage:report]
 fail_under = 95.50


### PR DESCRIPTION
Enable approved EDA tests/linters in galaxy-importer to run when running `local_image_build` and in the Openshift container on CRC. The linters will run over the `<collection_root>/extensions/eda/plugins/` dir. 

Linters:
- `ruff`
- `pylint`
- `darglint`

The tox.ini file used in import is not the file PE is distributing to partners. PE is distributing a more CI friendly version of the file, since this one is designed to run in the importer environment. 

Issue: AAH-2307