### PR TITLE
Fix CI

### DIFF
--- a/tests/integration/test_eda.py
+++ b/tests/integration/test_eda.py
@@ -34,10 +34,13 @@ def test_eda_import(workdir, local_image_config):
 
     # EDA specific messages ...
     assert "EDA plugin content found. Running ruff on /extensions/eda/plugins..." in log
+    # No errors in log to verify ruff ran
     assert "Running darglint on /extensions/eda/plugins..." in log
     assert "aws_sqs_queue.py:main:33: DAR101" in log
     assert "Running pylint on /extensions/eda/plugins/event_source..." in log
+    assert "aws_sqs_queue.py:29: [E0401" in log
     assert "Running pylint on /extensions/eda/plugins/event_filter..." in log
+    assert "insert_hosts_to_meta.py:53: [C0103" in log
     assert "EDA linting complete." in log
 
     assert "Removing temporary files, image and container" in log

--- a/tests/integration/test_eda.py
+++ b/tests/integration/test_eda.py
@@ -35,7 +35,6 @@ def test_eda_import(workdir, local_image_config):
     # EDA specific messages ...
     assert "EDA plugin content found. Running ruff on /extensions/eda/plugins..." in log
     assert "Running darglint on /extensions/eda/plugins..." in log
-    assert "aws_sqs_queue.py:70:21: PERF203" in log
     assert "Running pylint on /extensions/eda/plugins/event_source..." in log
     assert "Running pylint on /extensions/eda/plugins/event_filter..." in log
     assert "EDA linting complete." in log

--- a/tests/integration/test_eda.py
+++ b/tests/integration/test_eda.py
@@ -35,6 +35,7 @@ def test_eda_import(workdir, local_image_config):
     # EDA specific messages ...
     assert "EDA plugin content found. Running ruff on /extensions/eda/plugins..." in log
     assert "Running darglint on /extensions/eda/plugins..." in log
+    assert "aws_sqs_queue.py:main:33: DAR101" in log
     assert "Running pylint on /extensions/eda/plugins/event_source..." in log
     assert "Running pylint on /extensions/eda/plugins/event_filter..." in log
     assert "EDA linting complete." in log

--- a/tests/unit/test_schema_collection_info.py
+++ b/tests/unit/test_schema_collection_info.py
@@ -40,7 +40,7 @@ def collection_info():
 
 def test_collection_info(collection_info):
     res = CollectionInfo(**collection_info)
-    assert type(res) == CollectionInfo
+    assert isinstance(res, CollectionInfo)
     assert res.namespace == "acme"
     assert res.name == "jenkins"
     assert res.version == "3.5.0"

--- a/tests/unit/test_schema_filename.py
+++ b/tests/unit/test_schema_filename.py
@@ -56,7 +56,7 @@ def test_filename_parse():
 )
 def test_filename_format(filename_str):
     res = schema.CollectionFilename.parse(filename_str)
-    assert type(res) == schema.CollectionFilename
+    assert isinstance(res, schema.CollectionFilename)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Error PERF203 does not appear to exist in darglint anymore:
```
$ darglint --list-errors
DAR000: Failed to parse file due to syntax error.
DAR001: The docstring was not parsed correctly due to a syntax error.
DAR002: An argument/exception lacks a description
DAR003: A line is under-indented or over-indented.
DAR004: The docstring contains an extra newline where it shouldn't.
DAR005: The item contains a type section (parentheses), but no type.
DAR101: The docstring is missing a parameter in the definition.
DAR102: The docstring contains a parameter not in function.
DAR103: The docstring parameter type doesn't match function.
DAR104: The docstring parameter type is not given.
DAR105: The docstring parameter type is malformed. Expected parameter type to match syntax from PEP484. If your parameter contains parentheses, you may want to switch them to brackets.  E.g. `Union[str, int]`.
DAR201: The docstring is missing a return from definition.
DAR202: The docstring has a return not in definition.
DAR203: The docstring parameter type doesn't match function.
DAR301: The docstring is missing a yield present in definition.
DAR302: The docstring has a yield not in definition.
DAR401: The docstring is missing an exception raised.
DAR402: The docstring describes an exception not explicitly raised.
DAR501: The docstring describes a variable which is not defined.
```
Was also nerfed in Ruff about 3 weeks ago from what I found.

No-Issue