### PR TITLE
Add namespace parameter in legacy config

### DIFF
--- a/galaxy_importer/constants.py
+++ b/galaxy_importer/constants.py
@@ -64,7 +64,9 @@ LEGACY_ROLE_NAME_REGEXP = re.compile("^[a-zA-Z0-9_-]{1,55}$")
 # or single hyphens, and cannot begin or end with a hyphen
 # Some roles may contain underscores
 # Maximum of 39 char tested in the validator
-LEGACY_NAMESPACE_REGEXP = re.compile("^([a-zA-Z0-9]+[-_]?)*[a-zA-Z0-9]$")
+# For retrocompatibility with legacy role, allow names
+# finishing with hyphen or underscores, and names containing dots
+LEGACY_NAMESPACE_REGEXP = re.compile("^([a-zA-Z0-9.]+[-_]?)+$")
 
 
 class ContentCategory(enum.Enum):

--- a/galaxy_importer/constants.py
+++ b/galaxy_importer/constants.py
@@ -59,6 +59,12 @@ GITHUB_USERNAME_REGEXP = re.compile(r"^[a-zA-Z\d](?:[a-zA-Z\d]|-(?=[a-zA-Z\d])){
 # uppercase letters, numbers, underscores, and hyphens with
 # a length in the inclusive range [1, 55].
 LEGACY_ROLE_NAME_REGEXP = re.compile("^[a-zA-Z0-9-_]{1,55}$")
+# Matches namespaces: Namespace names should match any valid
+# GitHub username. Username may only contain alphanumeric characters
+# or single hyphens, and cannot begin or end with a hyphen
+# Some roles may contain underscores
+# Maximum of 39 char tested in the validator
+LEGACY_NAMESPACE_REGEXP = re.compile("^([a-zA-Z0-9]+[-_]?)*[a-zA-Z0-9]$")
 
 
 class ContentCategory(enum.Enum):

--- a/galaxy_importer/constants.py
+++ b/galaxy_importer/constants.py
@@ -58,7 +58,7 @@ GITHUB_USERNAME_REGEXP = re.compile(r"^[a-zA-Z\d](?:[a-zA-Z\d]|-(?=[a-zA-Z\d])){
 # Matches role names with any combination of lowercase letters,
 # uppercase letters, numbers, underscores, and hyphens with
 # a length in the inclusive range [1, 55].
-LEGACY_ROLE_NAME_REGEXP = re.compile("^[a-zA-Z0-9-_]{1,55}$")
+LEGACY_ROLE_NAME_REGEXP = re.compile("^[a-zA-Z0-9_-]{1,55}$")
 # Matches namespaces: Namespace names should match any valid
 # GitHub username. Username may only contain alphanumeric characters
 # or single hyphens, and cannot begin or end with a hyphen

--- a/galaxy_importer/schema.py
+++ b/galaxy_importer/schema.py
@@ -30,6 +30,7 @@ from galaxy_importer.utils.spdx_licenses import is_valid_license_id
 MAX_LENGTH_AUTHOR = 64
 MAX_LENGTH_LICENSE = 32
 MAX_LENGTH_NAME = 64
+MAX_LENGTH_NAMESPACE = 39
 MAX_LENGTH_TAG = 64
 MAX_LENGTH_URL = 2000
 MAX_LENGTH_VERSION = 128
@@ -388,6 +389,7 @@ class LegacyGalaxyInfo(object):
     """Represents legacy role metadata galaxy_info field."""
 
     role_name = attr.ib(default=None)
+    namespace = attr.ib(default=None)
     author = attr.ib(default=None)
     description = attr.ib(default=None)
     company = attr.ib(default=None)
@@ -400,6 +402,7 @@ class LegacyGalaxyInfo(object):
     galaxy_tags = attr.ib(factory=list)
 
     @role_name.validator
+    @namespace.validator
     @author.validator
     @description.validator
     @company.validator
@@ -438,6 +441,15 @@ class LegacyGalaxyInfo(object):
 
         if value is not None and not constants.LEGACY_ROLE_NAME_REGEXP.match(value):
             raise exc.LegacyRoleSchemaError(f"role name {value} is invalid")
+
+    @namespace.validator
+    def _validate_namespace(self, attribute, value):
+        """Ensure namespace matches the regular expression."""
+
+        if value is not None and (
+            not constants.LEGACY_NAMESPACE_REGEXP.match(value) or len(value) > MAX_LENGTH_NAMESPACE
+        ):
+            raise exc.LegacyRoleSchemaError(f"namespace {value} is invalid")
 
     @author.validator
     def _validate_author(self, attribute, value):

--- a/tests/integration/test_eda.py
+++ b/tests/integration/test_eda.py
@@ -40,7 +40,7 @@ def test_eda_import(workdir, local_image_config):
     assert "Running pylint on /extensions/eda/plugins/event_source..." in log
     assert "aws_sqs_queue.py:29: [E0401" in log
     assert "Running pylint on /extensions/eda/plugins/event_filter..." in log
-    assert "insert_hosts_to_meta.py:53: [C0103" in log
+    assert "insert_hosts_to_meta.py:31: [E0401" in log
     assert "EDA linting complete." in log
 
     assert "Removing temporary files, image and container" in log

--- a/tests/unit/test_loader_legacy.py
+++ b/tests/unit/test_loader_legacy.py
@@ -18,6 +18,7 @@ dependencies: []
 
 galaxy_info:
   role_name: my_role
+  namespace: my_namespace
   author: John Doe
   description: Some generic role description
   platforms:
@@ -96,6 +97,7 @@ def test_load_values(populated_role_root):
 
     galaxy_info = data.metadata.galaxy_info
     assert galaxy_info.role_name == "my_role"
+    assert galaxy_info.namespace == "my_namespace"
     assert galaxy_info.author == "John Doe"
     assert galaxy_info.description == "Some generic role description"
     assert galaxy_info.platforms == [


### PR DESCRIPTION
Hello
I propose to add the namespace in field of the LegacyGalaxyInfo class to solve the following:

I'm trying to validate a legacy role with both `galaxy-importer.main` and `ansible-lint`
If I have NO namespace in my `meta/main.yaml` I have the following error when executing ansible-lint:
```
ERROR    Computed fully qualified role name of datadog does not follow current galaxy requirements.
Please edit meta/main.yml and assure we can correctly determine full role name:

galaxy_info:
role_name: my_name  # if absent directory name hosting role is used instead
namespace: my_galaxy_namespace  # if absent, author is used instead

Namespace: https://galaxy.ansible.com/docs/contributing/namespaces.html#galaxy-namespace-limitations
Role: https://galaxy.ansible.com/docs/contributing/creating_role.html#role-names

As an alternative, you can add 'role-name' to either skip_list or warn_list.

Computed fully qualified role name of datadog does not follow current galaxy requirements.
Please edit meta/main.yml and assure we can correctly determine full role name:

galaxy_info:
role_name: my_name  # if absent directory name hosting role is used instead
namespace: my_galaxy_namespace  # if absent, author is used instead

Namespace: https://galaxy.ansible.com/docs/contributing/namespaces.html#galaxy-namespace-limitations
Role: https://galaxy.ansible.com/docs/contributing/creating_role.html#role-names

As an alternative, you can add 'role-name' to either skip_list or warn_list.
```
and when I have a namespace and execute galaxy-importer:
```
ERROR: The import failed for the following reason: unknown field in galaxy_info
```

Tests performed with 
```
Importing with galaxy-importer 0.4.13
ansible-lint 6.14.3 using ansible 2.15.4
```

With this PR I allow having a namespace in the configuration but still require namespace to be provided for galaxy-importer (`python -m galaxy_importer.main --legacy-role my-role --namespace my-namespace`)