### PR TITLE
Show more info when Legacy role galaxy info has unknown field

### DIFF
--- a/galaxy_importer/schema.py
+++ b/galaxy_importer/schema.py
@@ -531,7 +531,7 @@ class LegacyMetadata:
             try:
                 galaxy_info = LegacyGalaxyInfo(**metadata["galaxy_info"])
             except TypeError as e:
-                raise exc.LegacyRoleSchemaError("unknown field in galaxy_info") from e
+                raise exc.LegacyRoleSchemaError(f"unknown field in galaxy_info: {e}") from e
             dependencies = metadata.get("dependencies", list())
         return cls(galaxy_info, dependencies)
 


### PR DESCRIPTION
Currently during legacy role import, if galaxy_info has an unknown
field, we see the following message:

  unknown field in galaxy_info

This is not very helpful, and does not tell us how to fix the issue.

This change adds the cause of the issue to the exception message, so we
know which field to fix.
