### PR TITLE
Allow underscores in legacynamespace names

### DIFF
--- a/CHANGES/2820.bugfix
+++ b/CHANGES/2820.bugfix
@@ -1,0 +1,1 @@
+Allow underscores for old galaxy role namespace names.

--- a/galaxy_importer/constants.py
+++ b/galaxy_importer/constants.py
@@ -53,7 +53,11 @@ ALLOWED_EXTENSION_DIRS = [
     EDA_EVENT_FILTER_NAME,
 ]
 
-GITHUB_USERNAME_REGEXP = re.compile(r"^[a-zA-Z\d](?:[a-zA-Z\d]|-(?=[a-zA-Z\d])){0,38}$")
+# Match github's allowable usernames, but also include underscores
+# because of old-galaxy's preference for replacing hyphens with underscores
+# in namespace names. There are quite a few legacy namespaces with
+# underscores grandfathered in, so we must support those too.
+GITHUB_USERNAME_REGEXP = re.compile(r"^[a-zA-Z\d_](?:[a-zA-Z\d_]|-(?=[a-zA-Z\d])){0,38}$")
 
 # Matches role names with any combination of lowercase letters,
 # uppercase letters, numbers, underscores, and hyphens with

--- a/tests/unit/test_loader_legacy.py
+++ b/tests/unit/test_loader_legacy.py
@@ -120,7 +120,6 @@ def test_load_values(populated_role_root):
     "invalid_namespace",
     [
         "",
-        "a_b",
         "this--that",
         "foo-bar-",
         "-red-hat",


### PR DESCRIPTION
https://issues.redhat.com/browse/AAH-2820

```
# ansible-galaxy role import -s https://galaxy.ansible.com --role-name=docker radek-sprta ansible-role-docker
Successfully submitted import request 2053626989228472145217248830081447771
running
namespace radek_sprta is invalid
  File "/venv/lib64/python3.11/site-packages/pulpcore/tasking/tasks.py", line 66, in _execute_task
    result = func(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^
  File "/app/galaxy_ng/app/api/v1/tasks.py", line 370, in legacy_role_import
    result = import_legacy_role(checkout_path, namespace.name, importer_config, logger)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/galaxy_importer/legacy_role.py", line 51, in import_legacy_role
    return _import_legacy_role(dirname, namespace, cfg, logger)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/galaxy_importer/legacy_role.py", line 57, in _import_legacy_role
    data = LegacyRoleLoader(dirname, namespace, cfg, logger).load()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib64/python3.11/site-packages/galaxy_importer/loaders/legacy_role.py", line 39, in load
    self._validate_namespace()
  File "/venv/lib64/python3.11/site-packages/galaxy_importer/loaders/legacy_role.py", line 61, in _validate_namespace
    raise exc.ImporterError(f"namespace {self.namespace} is invalid")
```