### PR TITLE
Support `name` and `src` in dependencies

### DIFF
--- a/galaxy_importer/schema.py
+++ b/galaxy_importer/schema.py
@@ -549,10 +549,16 @@ class LegacyMetadata:
 
             _dependency = dependency
             if isinstance(dependency, dict):
-                if "role" not in dependency.keys():
-                    raise exc.LegacyRoleSchemaError("dependency must include 'role' keyword.")
-
-                _dependency = dependency["role"]
+                if "role" in dependency:
+                    _dependency = dependency.get("role", "")
+                elif "name" in dependency:
+                    _dependency = dependency.get("name", "")
+                elif "src" in dependency:
+                    _dependency = dependency.get("src", "")
+                else:
+                    raise exc.LegacyRoleSchemaError(
+                        "dependency must include either the 'role,' 'name,' or 'src' keyword."
+                    )
 
             if _dependency.count(".") != 1:
                 raise exc.LegacyRoleSchemaError(
@@ -598,7 +604,12 @@ class LegacyImportResult(object):
         for dependency in self.metadata.dependencies:
             _dependency = dependency
             if isinstance(dependency, dict):
-                _dependency = dependency.get("role", "")
+                if "role" in dependency:
+                    _dependency = dependency.get("role", "")
+                elif "name" in dependency:
+                    _dependency = dependency.get("name", "")
+                elif "src" in dependency:
+                    _dependency = dependency.get("src", "")
 
             namespace, name = _dependency.split(".")
             if self.namespace == namespace and self.name == name:

--- a/tests/unit/test_schema_legacy.py
+++ b/tests/unit/test_schema_legacy.py
@@ -241,8 +241,16 @@ def test_invalid_dependency_separation(galaxy_info):
         LegacyMetadata(LegacyGalaxyInfo(**galaxy_info), dependencies)
 
 
-def test_self_dependency(galaxy_info):
-    dependencies = ["someone.my_role"]
+@pytest.mark.parametrize(
+    "dependencies",
+    [
+        ["someone.my_role"],
+        [dict(role="someone.my_role")],
+        [{"name": "someone.my_role"}],
+        [{"src": "someone.my_role"}],
+    ],
+)
+def test_self_dependency(galaxy_info, dependencies):
     with pytest.raises(exc.LegacyRoleSchemaError, match="cannot depend on itself"):
         LegacyImportResult(
             "someone",

--- a/tests/unit/test_schema_legacy.py
+++ b/tests/unit/test_schema_legacy.py
@@ -194,10 +194,9 @@ def test_invalid_dependency_type(galaxy_info, invalid_dependency):
     "invalid_dict",
     [
         [dict()],
-        [dict(name="foo.bar")],
+        [dict(role_name="foo.bar")],
         [
             {
-                "name": "geerlingguy.nodejs",
                 "tags": ["nodejs"],
                 "vars": {"ignore_errors": "{{ ansible_check_mode }}"},
             }
@@ -207,7 +206,7 @@ def test_invalid_dependency_type(galaxy_info, invalid_dependency):
 def test_invalid_dependency_dict_type(galaxy_info, invalid_dict):
     with pytest.raises(
         exc.LegacyRoleSchemaError,
-        match="dependency must include 'role' keyword.",
+        match="dependency must include either the 'role,' 'name,' or 'src' keyword.",
     ):
         LegacyMetadata(LegacyGalaxyInfo(**galaxy_info), invalid_dict)
 
@@ -217,6 +216,8 @@ def test_invalid_dependency_dict_type(galaxy_info, invalid_dict):
     [
         ["geerlingguy.nodejs"],
         [dict(role="foo.bar")],
+        [{"name": "geerlingguy.docker"}],
+        [{"src": "galaxy.role,version,name"}],
         [
             {
                 "role": "geerlingguy.nodejs",

--- a/tests/unit/test_utils_string_utils.py
+++ b/tests/unit/test_utils_string_utils.py
@@ -1,0 +1,9 @@
+from galaxy_importer.utils import string_utils
+
+
+def test_removeprefix_startswith():
+    assert "bar" == string_utils.removeprefix("foobar", "foo")
+
+
+def test_removeprefix_doesnt_startswith():
+    assert "foobar" == string_utils.removeprefix("foobar", "baz")


### PR DESCRIPTION
No-Issue

I'm wondering if we should perform a more complex check for dependencies, such as the one for `src` at https://github.com/ansible/ansible/blob/devel/lib/ansible/playbook/role/metadata.py#L79 and valid keys in the dictionary, or if we should stick to a more loose check like this.