### PR TITLE
Adding linter ignores for EDA linters

### DIFF
--- a/CHANGES/2997.bugfix
+++ b/CHANGES/2997.bugfix
@@ -1,0 +1,1 @@
+Ignore certain linter rules for ruff and pylint inside the EDA tox tests. 

--- a/galaxy_importer/ansible_test/container/eda/tox.ini
+++ b/galaxy_importer/ansible_test/container/eda/tox.ini
@@ -7,7 +7,7 @@ requires =
 
 [testenv:ruff]
 deps = ruff
-commands = - ruff check --select ALL --ignore INP001 -q {posargs}/extensions/eda/plugins
+commands = - ruff check --select ALL --ignore INP001,FA102,UP001,UP010,I001,FA100 -q {posargs}/extensions/eda/plugins
 
 
 [testenv:darglint]
@@ -17,8 +17,8 @@ commands = - darglint -s numpy -z full {posargs}/extensions/eda/plugins
 
 [testenv:pylint-event-source]
 deps = pylint
-commands = - pylint {posargs}/extensions/eda/plugins/event_source/*.py --output-format=parseable -sn --disable R0801
+commands = - pylint {posargs}/extensions/eda/plugins/event_source/*.py --output-format=parseable -sn --disable R0801,E0401,C0103,R0913
 
 [testenv:pylint-event-filter]
 deps = pylint
-commands = - pylint {posargs}/extensions/eda/plugins/event_filter/*.py --output-format=parseable -sn --disable R0801
+commands = - pylint {posargs}/extensions/eda/plugins/event_filter/*.py --output-format=parseable -sn --disable R0801,E0401,C0103,R0913

--- a/tests/integration/test_eda.py
+++ b/tests/integration/test_eda.py
@@ -38,9 +38,7 @@ def test_eda_import(workdir, local_image_config):
     assert "Running darglint on /extensions/eda/plugins..." in log
     assert "aws_sqs_queue.py:main:33: DAR101" in log
     assert "Running pylint on /extensions/eda/plugins/event_source..." in log
-    assert "aws_sqs_queue.py:29: [E0401" in log
     assert "Running pylint on /extensions/eda/plugins/event_filter..." in log
-    assert "insert_hosts_to_meta.py:31: [E0401" in log
     assert "EDA linting complete." in log
 
     assert "Removing temporary files, image and container" in log


### PR DESCRIPTION
Adding ignores for certain linter tests inside of the EDA tox test. These ignores are added for the following reasons:

Ruff:
- [FA100](https://docs.astral.sh/ruff/rules/future-rewritable-type-annotation/): Conflicts with ansible-test sanity 
- [FA102](https://docs.astral.sh/ruff/rules/future-required-type-annotation/): Conflicts with ansible-test sanity
- [UP001](https://docs.astral.sh/ruff/rules/useless-metaclass-type/): Internal test conflict between pylint and ruff
- [UP010](https://docs.astral.sh/ruff/rules/unnecessary-future-import/): Conflicts with ansible-test sanity
- [I001](https://docs.astral.sh/ruff/rules/unsorted-imports/): Can conflict with ansible-test sanity

Pylint:
- [E0401](https://pylint.readthedocs.io/en/latest/user_guide/messages/error/import-error.html): Red herring error resulting from how tox builds linter envs 
- [C0103](https://pylint.readthedocs.io/en/stable/user_guide/messages/convention/invalid-name.html): Internal test conflict between pylint and ruff
- [R0913](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/too-many-arguments.html): Unnecessary test

Issue: AAH-2997