### PR TITLE
Fix link target generation for collection test

### DIFF
--- a/galaxy_importer/collection.py
+++ b/galaxy_importer/collection.py
@@ -165,7 +165,9 @@ def _extract_archive(fileobj, extract_dir):
                 raise exc.ImporterError("Invalid file paths detected.")
             if item.linkname:
                 # Ensure the link target is within the extraction root
-                link_target = os.path.normpath(os.path.join(extract_dir, item.linkname))
+                link_target = os.path.normpath(
+                    os.path.join(extract_dir, os.path.dirname(item.name), item.linkname)
+                )
                 if not link_target.startswith(os.path.abspath(extract_dir)):
                     raise exc.ImporterError("Invalid link target detected.")
         tf.extractall(extract_dir)


### PR DESCRIPTION
The link_target was generated only using the extract_dir and the linkname, but without the directory path that contains the link. Therefore the link_target could be outside of the extract_dir.