### PR TITLE
Additional EDA test ignores

### DIFF
--- a/galaxy_importer/ansible_test/container/eda/tox.ini
+++ b/galaxy_importer/ansible_test/container/eda/tox.ini
@@ -7,7 +7,7 @@ requires =
 
 [testenv:ruff]
 deps = ruff
-commands = - ruff check --select ALL --ignore INP001,FA102,UP001,UP010,I001,FA100 -q {posargs}/extensions/eda/plugins
+commands = - ruff check --select ALL --ignore INP001,FA102,UP001,UP010,I001,FA100,PLR0913,E501 -q {posargs}/extensions/eda/plugins
 
 
 [testenv:darglint]
@@ -17,8 +17,8 @@ commands = - darglint -s numpy -z full {posargs}/extensions/eda/plugins
 
 [testenv:pylint-event-source]
 deps = pylint
-commands = - pylint {posargs}/extensions/eda/plugins/event_source/*.py --output-format=parseable -sn --disable R0801,E0401,C0103,R0913
+commands = - pylint {posargs}/extensions/eda/plugins/event_source/*.py --output-format=parseable -sn --disable R0801,E0401,C0103,R0913,R0902,R0903
 
 [testenv:pylint-event-filter]
 deps = pylint
-commands = - pylint {posargs}/extensions/eda/plugins/event_filter/*.py --output-format=parseable -sn --disable R0801,E0401,C0103,R0913
+commands = - pylint {posargs}/extensions/eda/plugins/event_filter/*.py --output-format=parseable -sn --disable R0801,E0401,C0103,R0913,R0902,R0903


### PR DESCRIPTION
Adds additional ignores for EDA tox linters.

These ignores are added for the following reasons:
Ruff:
[PLR0913](https://docs.astral.sh/ruff/rules/too-many-arguments/): Subjective, not needed for certification
[E501](https://docs.astral.sh/ruff/rules/line-too-long/): Conflicts with Pylint test, and subjective, not needed for certification

Pylint:
[R0902](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/too-many-instance-attributes.html): Subjective, not needed for certification
[R0903](https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/too-few-public-methods.html): Subjective, not needed for certification

(Changelog 2997.bugfix provides coverage for this change)

Issue: AAH-2997