### PR TITLE
Pin the pypi action to a specific version.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,6 @@ jobs:
         python -m build --sdist --wheel --outdir dist/ .
 
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.pypi_token }}


### PR DESCRIPTION
https://github.com/ansible/galaxy-importer/actions/runs/7573897653

[Build and publish to PyPI registry: # >> PyPA publish to PyPI GHA: UNSUPPORTED GITHUB ACTION VERSION <<#L1](https://github.com/ansible/galaxy-importer/commit/aee9b9e521019036fb461cce5ae875a6de429eb2#annotation_17094603878)
 You are using "pypa/gh-action-pypi-publish@master". The "master" branch of this project has been sunset and will not receive any updates, not even security bug fixes. Please, make sure to use a supported version. If you want to pin to v1 major version, use "pypa/gh-action-pypi-publish@release/v1". If you feel adventurous, you may opt to use use "pypa/gh-action-pypi-publish@unstable/v1" instead. A more general recommendation is to pin to exact tags or commit shas.