### PR TITLE
Updating changelog check to include the docs/ dir

### DIFF
--- a/CHANGES/3083.feature
+++ b/CHANGES/3083.feature
@@ -1,0 +1,1 @@
+Expand changelog check to the docs/ dir and add config option (default=True)

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ ANSIBLE_LOCAL_TMP = '~/.ansible/tmp'
 
 - `LOCAL_IMAGE_DOCKER` - Set to `True` to run the `ansible-test` container image via Docker; otherwise, Podman will be used. Defaults to `False`.
 
+- `CHECK_CHANGELOG` - Set to `False` to not check for a `CHANGELOG.rst or` `CHANGELOG.md` file under the collection root or `docs/` dir, or a `changelogs/changelog.yml` file. Defaults to `True`. 
+
 
 
 ### Issues and Process
@@ -78,3 +80,8 @@ ANSIBLE_LOCAL_TMP = '~/.ansible/tmp'
 To file an issue, visit the [Automation Hub Jira project](https://issues.redhat.com/projects/AAH/issues)
 
 Process details for `galaxy-importer`: [PROCESS.md](PROCESS.md)
+
+
+### Additional Notes
+
+Place `.md` files in the `docs/` dir to have them show up in an imported collection's "Documentation" tab on Galaxy or Automation Hub.  

--- a/galaxy_importer/config.py
+++ b/galaxy_importer/config.py
@@ -43,6 +43,7 @@ class Config(object):
     DEFAULTS = {
         "ansible_local_tmp": "~/.ansible/tmp",
         "ansible_test_local_image": False,
+        "check_changelog": True,
         "check_required_tags": False,
         "infra_osd": False,
         "local_image_docker": False,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -57,6 +57,7 @@ def test_config_set_from_file(temp_config_file):
         assert cfg.log_level_main == "INFO"
         assert cfg.run_ansible_test is True
         assert cfg.ansible_test_local_image is True
+        assert cfg.check_changelog is True
         assert cfg.local_image_docker is True
         assert cfg.infra_osd is False
         assert cfg.tmp_root_dir == "/tmp"

--- a/tests/unit/test_loader_collection.py
+++ b/tests/unit/test_loader_collection.py
@@ -207,6 +207,7 @@ def test_manifest_success(_build_docs_blob, populated_collection_root):
         cfg=SimpleNamespace(
             run_ansible_doc=True,
             run_ansible_lint=False,
+            check_changelog=False,
             ansible_local_tmp=populated_collection_root,
         ),
     ).load()
@@ -382,6 +383,7 @@ def test_filename_empty_value(_build_docs_blob, populated_collection_root):
         cfg=SimpleNamespace(
             run_ansible_doc=True,
             run_ansible_lint=False,
+            check_changelog=False,
             ansible_local_tmp=populated_collection_root,
         ),
     ).load()
@@ -400,6 +402,7 @@ def test_filename_none(_build_docs_blob, populated_collection_root):
         filename,
         cfg=SimpleNamespace(
             run_ansible_doc=True,
+            check_changelog=False,
             run_ansible_lint=False,
             ansible_local_tmp=populated_collection_root,
         ),
@@ -428,6 +431,7 @@ def test_license_file(populated_collection_root):
         cfg=SimpleNamespace(
             run_ansible_doc=True,
             run_ansible_lint=False,
+            check_changelog=False,
             ansible_local_tmp=populated_collection_root,
         ),
     ).load()
@@ -446,7 +450,14 @@ def test_missing_readme(populated_collection_root):
 
 
 @pytest.mark.parametrize(
-    "changelog_path", ["CHANGELOG.rst", "CHANGELOG.md", "changelogs/changelog.yaml"]
+    "changelog_path",
+    [
+        "CHANGELOG.rst",
+        "docs/CHANGELOG.rst",
+        "docs/CHANGELOG.md",
+        "CHANGELOG.md",
+        "changelogs/changelog.yaml",
+    ],
 )
 def test_changelog(changelog_path, tmpdir, caplog):
     dirname = os.path.dirname(changelog_path)
@@ -472,13 +483,14 @@ def test_changelog_fail(_build_docs_blob, populated_collection_root, caplog):
         cfg=SimpleNamespace(
             run_ansible_doc=True,
             run_ansible_lint=False,
+            check_changelog=True,
             ansible_local_tmp=populated_collection_root,
         ),
     ).load()
     assert (
         "No changelog found. "
-        "Add a CHANGELOG.rst, CHANGELOG.md, or changelogs/changelog.yaml file."
-        in str(caplog.records[0])
+        "Add a CHANGELOG.rst or CHANGELOG.md file in the collection root or docs/ dir, or a "
+        "changelogs/changelog.yaml file." in str(caplog.records[0])
     )
 
 
@@ -554,6 +566,7 @@ def test_ansiblelint_playbook_errors(populated_collection_root, tmp_collection_r
         cfg=SimpleNamespace(
             run_ansible_doc=False,
             run_ansible_lint=True,
+            check_changelog=False,
             offline_ansible_lint=True,
             ansible_local_tmp=tmp_collection_root,
         ),
@@ -587,13 +600,14 @@ def test_ansiblelint_true_loader(populated_collection_root, tmp_collection_root,
         cfg=SimpleNamespace(
             run_ansible_doc=False,
             run_ansible_lint=True,
+            check_changelog=False,
             offline_ansible_lint=True,
             ansible_local_tmp=tmp_collection_root,
         ),
     )
     collection_loader.load()
 
-    assert len(caplog.records) == 1  # Changelog error expected
+    assert len(caplog.records) == 0
 
 
 def test_ansiblelint_collection_role_errors(populated_collection_root, tmp_collection_root, caplog):

--- a/tests/unit/test_loader_doc_string.py
+++ b/tests/unit/test_loader_doc_string.py
@@ -24,7 +24,8 @@ from galaxy_importer import config
 from galaxy_importer import loaders
 
 
-ANSIBLE_DOC_OUTPUT = json.loads("""
+ANSIBLE_DOC_OUTPUT = json.loads(
+    """
     {
         "my_module": {
             "return": {
@@ -38,7 +39,8 @@ ANSIBLE_DOC_OUTPUT = json.loads("""
             }
         }
     }
-""")
+"""
+)
 
 
 @pytest.fixture
@@ -370,7 +372,6 @@ def test_transform_doc_strings_nested_suboptions(doc_string_loader):
 def test_load_function(
     mocked_run_ansible_doc_list, mocked_run_ansible_doc, doc_string_loader, tmpdir
 ):
-
     doc_string_loader.path = str(tmpdir)
     tmpdir.mkdir("plugins").mkdir("modules").join("my_module.py").write("")
 


### PR DESCRIPTION
Issue: AAH-3083

Update the changelog check to look under the `docs/` dir as well as the collection root for a changelog file, in case maintainers want to display their changelog.md files in the Galaxy UI ("Documentation") tab, or just want to store their changelog files under `docs/`.

Also add the ability to turn this check off by adding a config value, defaulting to `True` since this check was already running on all imports previously. 

Also add a section to the README "Additional Notes", with info about .md files (or HTML render-able files) in the `docs/` dir displaying in the "Documentation" tab on Galaxy and Automation Hub. 
 