### PR TITLE
Upgrading ansible-lint to 6.22.1

### DIFF
--- a/CHANGES/2805.feature
+++ b/CHANGES/2805.feature
@@ -1,0 +1,1 @@
+Upgrading the ansible-lint dependency upper bound from 6.14.3 to 6.22.1. 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ packages = find:
 install_requires =
     ansible-core
     ansible-builder>=1.2.0,<4.0
-    ansible-lint>=6.2.2,<=6.14.3
+    ansible-lint>=6.2.2,<=6.22.1
     attrs>=21.4.0,<23
     bleach>=3.3.0,<4
     bleach-allowlist>=1.0.3,<2

--- a/tests/integration/test_containers.py
+++ b/tests/integration/test_containers.py
@@ -69,7 +69,6 @@ def test_local_build_container_with_legacy_role(local_image_config, simple_legac
     assert "Should change default metadata: author" in log
     assert "Should change default metadata: company" in log
     assert "Should change default metadata: license" in log
-    assert "Role info should contain platforms" in log
     assert "All plays should be named." in log
     assert "...ansible-lint run complete" in log
     assert "Legacy role loading complete" in log

--- a/tests/unit/test_loader_collection.py
+++ b/tests/unit/test_loader_collection.py
@@ -72,7 +72,7 @@ MANIFEST_JSON = """
   "name": "FILES.json",
   "ftype": "file",
   "chksum_type": "sha256",
-  "chksum_sha256": "180adef53c071ed614891944413d684e3e19b5c5a31d8e3b5b8c1621206c4daa",
+  "chksum_sha256": "7bcaa4f0cb3d8ba4bc0891435786dc9f3888dc06ad3896872cd1d728ddf04edb",
   "format": 1
  }
 }
@@ -114,7 +114,7 @@ FILES_JSON = """
    "name": "meta/runtime.yml",
    "ftype": "file",
    "chksum_type": "sha256",
-   "chksum_sha256": "b712cf98238ae609938aad4838c849c5a492069a328647b9bf991244a33ff942",
+   "chksum_sha256": "50f2f6ed064dbadfc976560a9cd614695920846d8b12a2ceb1d5981da9af1f85",
    "format": 1
   }
  ]
@@ -126,7 +126,7 @@ This collection is public domain. No rights Reserved.
 """
 
 META_RUNTIME_YAML = """---
-requires_ansible: '>=2.9.10,<2.11.5'
+requires_ansible: '>=2.15.0'
 plugin_routing:
   modules:
     set_config:


### PR DESCRIPTION
Upgrading the upper bound req for ansible-lint from 6.14.3 to 6.22.1. 

This is to include a number of fixes and test updates in the newer version. 

Issue: AAH-2805