### PR TITLE
Updating ansible-core version to 2.16, python to 3.11, and base-test-container

### DIFF
--- a/CHANGES/3156.misc
+++ b/CHANGES/3156.misc
@@ -1,1 +1,1 @@
-Update ansible-test base image and ansible-core including Python bump from 3.9 to 3.11.
+Update ansible-test base image and ansible-core, including Python bump from 3.9 to 3.11.

--- a/CHANGES/3156.misc
+++ b/CHANGES/3156.misc
@@ -1,0 +1,1 @@
+Update ansible-test base image and ansible-core including Python bump from 3.9 to 3.10

--- a/CHANGES/3156.misc
+++ b/CHANGES/3156.misc
@@ -1,1 +1,1 @@
-Update ansible-test base image and ansible-core including Python bump from 3.9 to 3.10
+Update ansible-test base image and ansible-core including Python bump from 3.9 to 3.10.

--- a/CHANGES/3156.misc
+++ b/CHANGES/3156.misc
@@ -1,1 +1,1 @@
-Update ansible-test base image and ansible-core including Python bump from 3.9 to 3.10.
+Update ansible-test base image and ansible-core including Python bump from 3.9 to 3.11.

--- a/galaxy_importer/ansible_test/container/Dockerfile
+++ b/galaxy_importer/ansible_test/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ansible/base-test-container:4.1.0
+FROM quay.io/ansible/base-test-container:5.10.0
 
 COPY entrypoint.sh /entrypoint
 
@@ -16,8 +16,8 @@ RUN useradd user1 \
     mkdir -p -m 0775 /ansible_collections /ansible_collections/ns /ansible_collections/ns/col && \
     touch /ansible_collections/ns/col/placeholder.txt && \
     # On updating ansible-core version, update the FROM statement to the matching base-test-container version
-    python3.9 -m pip install ansible-core==2.15.0 --disable-pip-version-check && \
-    python3.9 -m pip install tox && \
+    python3.10 -m pip install ansible-core==2.16.0 --disable-pip-version-check && \
+    python3.10 -m pip install tox && \
     # Creates dir with correct permissions for where ansible-test sanity writes files, needed for non-privileged containers
     mkdir -m 0775 -p /.cache/pylint && \
     mkdir -m 0775 -p /eda /eda/tox

--- a/galaxy_importer/ansible_test/container/Dockerfile
+++ b/galaxy_importer/ansible_test/container/Dockerfile
@@ -16,8 +16,8 @@ RUN useradd user1 \
     mkdir -p -m 0775 /ansible_collections /ansible_collections/ns /ansible_collections/ns/col && \
     touch /ansible_collections/ns/col/placeholder.txt && \
     # On updating ansible-core version, update the FROM statement to the matching base-test-container version
-    python3.10 -m pip install ansible-core==2.16.0 --disable-pip-version-check && \
-    python3.10 -m pip install tox && \
+    python3.11 -m pip install ansible-core==2.16.0 --disable-pip-version-check && \
+    python3.11 -m pip install tox && \
     # Creates dir with correct permissions for where ansible-test sanity writes files, needed for non-privileged containers
     mkdir -m 0775 -p /.cache/pylint && \
     mkdir -m 0775 -p /eda /eda/tox


### PR DESCRIPTION

Updating base-test-container in the Dockerfile to 5.10.0 per https://github.com/ansible/ansible/blob/stable-2.16/test/lib/ansible_test/_data/completion/docker.txt

Updating the version of ansible-core used in the Dockerfile to 2.16.0 to align with AAP 2.5 requirements.

Hold this until the AAP 2.5 release.

Issue: AAH-3156