### PR TITLE
Updating ansible-lint version cap to 24.6.0

### DIFF
--- a/CHANGES/3227.feature
+++ b/CHANGES/3227.feature
@@ -1,0 +1,1 @@
+Upgrading the ansible-lint dependency upper bound from 6.22.1 to 24.6.0.

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ packages = find:
 install_requires =
     ansible-core
     ansible-builder>=1.2.0,<4.0
-    ansible-lint>=6.2.2,<=6.22.1
+    ansible-lint>=6.2.2,<=24.6.0
     attrs>=21.4.0,<23
     bleach>=3.3.0,<4
     bleach-allowlist>=1.0.3,<2


### PR DESCRIPTION
Updating ansible-lint cap to 24.6.0. Tests are passing and expected import behavior is occurring. 

The jump in versioning is because ansible-lint switched to using CalVer after 6.22.2. So, the cap change is not as significant as it may look initially. See the ansible-lint releases page [here](https://github.com/ansible/ansible-lint/releases) for details. 

Note: ansible-lint 24.6.0 requires Python 3.10 at minimum. Since the lint dependency in galaxy-importer has a minimum of 6.2.2, the Python 3.9 tests are using lint 6.22.2, which is the last version of ansible-lint that works with Python 3.9. 



Issue: AAH-3227