### PR TITLE
Adding changelog.yml as a valid changelog

### DIFF
--- a/CHANGES/3290.bugfix
+++ b/CHANGES/3290.bugfix
@@ -1,0 +1,1 @@
+Adding changelogs/changelog.yml as an accepted changelog path.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ ANSIBLE_LOCAL_TMP = '~/.ansible/tmp'
 
 - `ANSIBLE_TEST_LOCAL_IMAGE` - Set to `True` to run `ansible-test` sandboxed within a container image. Requires installation of either Podman or Docker to run the container. Defaults to `False`.
 
-- `CHECK_CHANGELOG` - Set to `False` to not check for a `CHANGELOG.rst or` `CHANGELOG.md` file under the collection root or `docs/` dir, or a `changelogs/changelog.yml` file. Defaults to `True`. 
+- `CHECK_CHANGELOG` - Set to `False` to not check for a `CHANGELOG.rst or` `CHANGELOG.md` file under the collection root or `docs/` dir, or a `changelogs/changelog.(yml/yaml)` file. Defaults to `True`. 
 
 - `CHECK_REQUIRED_TAGS` - Set to `True` to check for a set of tags required for Ansible collection certification. Defaults to `False`. 
 

--- a/galaxy_importer/loaders/collection.py
+++ b/galaxy_importer/loaders/collection.py
@@ -207,8 +207,8 @@ class CollectionLoader(object):
             self.log.warning(IGNORE_WARNING.format(file=ignore_file, line_count=line_count))
 
     def _check_collection_changelog(self):
-        """Log an error when a CHANGELOG file is not present in the root"
-        " or docs/ dir of the collection."""
+        """Log an error when a CHANGELOG file is not present in the root,"
+        " docs/ dir, or changelogs/ dir of the collection."""
         changelog = False
         changelog_paths = [
             "CHANGELOG.rst",
@@ -216,6 +216,7 @@ class CollectionLoader(object):
             "docs/CHANGELOG.md",
             "docs/CHANGELOG.rst",
             "changelogs/changelog.yaml",
+            "changelogs/changelog.yml",
         ]
 
         for log_path in changelog_paths:
@@ -227,7 +228,7 @@ class CollectionLoader(object):
             self.log.warning(
                 "No changelog found. "
                 "Add a CHANGELOG.rst or CHANGELOG.md file in the collection root "
-                "or docs/ dir, or a changelogs/changelog.yaml file."
+                "or docs/ dir, or a changelogs/changelog.(yml/yaml) file."
             )
 
     def _check_ee_yml_dep_files(self):  # pragma: no cover

--- a/tests/unit/test_loader_collection.py
+++ b/tests/unit/test_loader_collection.py
@@ -457,6 +457,7 @@ def test_missing_readme(populated_collection_root):
         "docs/CHANGELOG.md",
         "CHANGELOG.md",
         "changelogs/changelog.yaml",
+        "changelogs/changelog.yml",
     ],
 )
 def test_changelog(changelog_path, tmpdir, caplog):
@@ -489,8 +490,8 @@ def test_changelog_fail(_build_docs_blob, populated_collection_root, caplog):
     ).load()
     assert (
         "No changelog found. "
-        "Add a CHANGELOG.rst or CHANGELOG.md file in the collection root or docs/ dir, or a "
-        "changelogs/changelog.yaml file." in str(caplog.records[0])
+        "Add a CHANGELOG.rst or CHANGELOG.md file in the collection root "
+        "or docs/ dir, or a changelogs/changelog.(yml/yaml) file." in str(caplog.records[0])
     )
 
 


### PR DESCRIPTION
Adding `changelogs/changelog.yml` as an accepted changelog path. 

See https://github.com/ansible/ansible-lint/issues/4105 and https://github.com/ansible/ansible-lint/pull/4218

Issue: AAH-3290