### PR TITLE
Add details about related ansible project versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+### Ansible Requirements
+
+``galaxy-importer`` requires the following other Ansible projects:
+
+* ``ansible-lint`` up to [24.6.0](https://github.com/ansible/ansible-lint/releases/tag/v24.6.0)
+* ``ansible-core`` up to [2.16](https://docs.ansible.com/ansible-core/2.16/index.html)
+
+If you are installing from source, see ``setup.cfg`` in the repository for the matching requirements.
+
 ### Install
 
 #### From pypi

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ``galaxy-importer`` requires the following other Ansible projects:
 
-* ``ansible-lint`` up to [24.6.0](https://github.com/ansible/ansible-lint/releases/tag/v24.6.0)
+* ``ansible-lint`` up to [24.6.0](https://github.com/ansible/ansible-lint/tree/v24.6.0/docs)
 * ``ansible-core`` up to [2.16](https://docs.ansible.com/ansible-core/2.16/index.html)
 
 If you are installing from source, see ``setup.cfg`` in the repository for the matching requirements.


### PR DESCRIPTION
Users are finding it difficult to track which ansible-lint version to use when testing with galaxy-importer locally. Add some tidbits to help them along.

No-Issue