### PR TITLE
Upgraded ansible-lint upper bound to 24.7.0

### DIFF
--- a/CHANGES/3300.feature
+++ b/CHANGES/3300.feature
@@ -1,0 +1,1 @@
+Upgraded the ansible-lint dependency upper bound from 24.6.1 to 24.7.0. 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ``galaxy-importer`` requires the following other Ansible projects:
 
-* ``ansible-lint`` up to [24.6.1](https://github.com/ansible/ansible-lint/tree/v24.6.1/docs)
+* ``ansible-lint`` up to [24.7.0](https://github.com/ansible/ansible-lint/tree/v24.7.0/docs)
 * ``ansible-core`` up to [2.16](https://docs.ansible.com/ansible-core/2.16/index.html)
 
 If you are installing from source, see ``setup.cfg`` in the repository for the matching requirements.

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ packages = find:
 install_requires =
     ansible-core
     ansible-builder>=1.2.0,<4.0
-    ansible-lint>=6.2.2,<=24.6.1
+    ansible-lint>=6.2.2,<=24.7.0
     attrs>=21.4.0,<23
     bleach>=3.3.0,<4
     bleach-allowlist>=1.0.3,<2


### PR DESCRIPTION
This is another ansible-lint bump because ansible-lint's ADT version has been updated to 24.7.0. Release of galaxy-importer:0.4.24 to follow. 

Issue: AAH-3300