### PR TITLE
add support for parsing filter-type and test-type plugins via yaml files (reopened)

### DIFF
--- a/galaxy_importer/finder.py
+++ b/galaxy_importer/finder.py
@@ -67,7 +67,10 @@ class ContentFinder(object):
         """Find all python files anywhere inside content_dir."""
         for path, _, files in os.walk(content_dir):
             for file in files:
-                if not file.endswith(".py") or file == "__init__.py":
+                if file == "__init__.py" or not (
+                    file.endswith(".py") or file.endswith(".yaml") or
+                    file.endswith(".yml")
+                ):
                     continue
                 file_path = os.path.join(path, file)
                 rel_path = os.path.relpath(file_path, self.path)


### PR DESCRIPTION
Hi,

reopened #201 because I found that the filter and test documentation provided as yaml are are not parsed yet.

Example:

- plugins/filter/dict_filter.py defines the filters "my_dict_filter_foo", "my_dict_filter_bar" etc.
- plugins/filter/my_dict_filter_foo.yml, plugins/filter/my_dict_filter_bar.yml providing the corresponding documentation

Ansible-doc is able to display the filter and test documentation provided as yaml files, while galaxy-importer ignores them.
This PR adds "yaml" and "yml" extensions to the parseable files.