### PR TITLE
Add labels to dockerfile

### DIFF
--- a/galaxy_importer/ansible_test/container/Dockerfile
+++ b/galaxy_importer/ansible_test/container/Dockerfile
@@ -1,5 +1,17 @@
 FROM quay.io/ansible/base-test-container:5.10.0
 
+LABEL   com.redhat.component="ansible-test" \
+        description="Container used by galaxy for running ansible-test validation." \
+        distribution-scope="public" \
+        io.k8s.description="Container used by galaxy for running ansible-test validation." \
+        maintainer="Red Hat, Inc." \
+        name="galaxy-importer" \
+        release="0.4.26" \
+        summary="Container used by galaxy for running ansible-test validation." \
+        url="https://github.com/ansible/galaxy-importer" \
+        vendor="Red Hat, Inc." \
+        version="0.4.26"
+
 COPY entrypoint.sh /entrypoint
 
 RUN useradd user1 \


### PR DESCRIPTION
Adds LABELs to the image required to pass the Konflux enterprise-contract tests for image releases

These labels are already present in UBI images, so these can be removed if/when we migrate to a UBI base image.