### PR TITLE
Upgraded ansible-lint upper bound to 25.1.2

### DIFF
--- a/CHANGES/38371.feature
+++ b/CHANGES/38371.feature
@@ -1,0 +1,1 @@
+Upgraded the ansible-lint dependency upper bound from 24.9.0 to 25.1.2.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ``galaxy-importer`` requires the following other Ansible projects:
 
-* ``ansible-lint`` up to [24.9.0](https://github.com/ansible/ansible-lint/tree/v24.9.0/docs)
+* ``ansible-lint`` up to [25.1.2](https://github.com/ansible/ansible-lint/tree/v25.1.2/docs)
 * ``ansible-core`` up to [2.16](https://docs.ansible.com/ansible-core/2.16/index.html)
 
 If you are installing from source, see ``setup.cfg`` in the repository for the matching requirements.

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ packages = find:
 install_requires =
     ansible-core
     ansible-builder>=1.2.0,<4.0
-    ansible-lint>=6.2.2,<=24.9.0
+    ansible-lint>=6.2.2,<=25.1.2
     attrs>=21.4.0,<23
     nh3>=0.2.18,<3  # replaces bleach
     flake8>=5.0.0,<7

--- a/tests/unit/test_loader_collection.py
+++ b/tests/unit/test_loader_collection.py
@@ -631,10 +631,8 @@ def test_ansiblelint_collection_role_errors(populated_collection_root, tmp_colle
     collection_loader._lint_collection()
     shutil.rmtree(task_dir)
 
-    assert "name[casing]: All names should start with an uppercase letter." in str(
-        caplog.records[0]
-    )
-    assert "jinja[spacing]: Jinja2 spacing could be improved:" in str(caplog.records[1])
+    assert "All names should start with an uppercase letter." in str(caplog.records[0])
+    assert "Jinja2 spacing could be improved:" in str(caplog.records[1])
 
 
 def test_ansiblelint_collection_meta_runtime_errors(


### PR DESCRIPTION
Upgrading ansible-lint cap to 25.1.2 to match downstream package requirements.

Issue: [AAP-38371](https://issues.redhat.com/browse/AAP-38371)

