### PR TITLE
Support plugins with sidecar documentation

### DIFF
--- a/galaxy_importer/constants.py
+++ b/galaxy_importer/constants.py
@@ -75,7 +75,7 @@ LEGACY_ROLE_NAME_REGEXP = re.compile("^[a-zA-Z0-9_-]{1,55}$")
 LEGACY_NAMESPACE_REGEXP = re.compile("^([a-zA-Z0-9.]+[-_]?)+$")
 
 
-class ContentCategory(enum.Enum):
+class ContentCategory(str, enum.Enum):
     MODULE = "module"
     ROLE = "role"
     PLUGIN = "plugin"
@@ -83,7 +83,7 @@ class ContentCategory(enum.Enum):
     EXTENSION = "extension"
 
 
-class ContentType(enum.Enum):
+class ContentType(str, enum.Enum):
     PLAYBOOK = "playbook"
     ROLE = "role"
     MODULE = "module"

--- a/tests/integration/test_collections.py
+++ b/tests/integration/test_collections.py
@@ -50,7 +50,7 @@ def test_collection_community_general_import(workdir, local_fast_config):
 
     # make sure it found all the files
     contents = {(x["content_type"], x["name"]): x for x in results["contents"]}
-    assert len(contents.keys()) == 831
+    assert len(contents.keys()) == 842
 
     # check a small sample
     assert ("test", "a_module") in contents
@@ -69,7 +69,7 @@ def test_collection_community_general_import(workdir, local_fast_config):
     docs_contents = {
         (x["content_type"], x["content_name"]): x for x in results["docs_blob"]["contents"]
     }
-    assert len(docs_contents.keys()) == 831
+    assert len(docs_contents.keys()) == 842
 
     # check a small sample
     assert ("test", "a_module") in docs_contents

--- a/tests/integration/test_eda.py
+++ b/tests/integration/test_eda.py
@@ -50,13 +50,13 @@ def test_eda_import(workdir, local_image_config):
 
     # the data should have all the relevant bits
     assert results["contents"] == [
-        {"content_type": "playbook", "description": None, "name": "hello.yml"},
-        {"content_type": "role", "description": "your role description", "name": "test_role"},
         {
             "content_type": "module",
             "description": "Upper cases a passed in string",
             "name": "upcase",
         },
+        {"content_type": "playbook", "description": None, "name": "hello.yml"},
+        {"content_type": "role", "description": "your role description", "name": "test_role"},
     ]
     assert results["docs_blob"]["contents"] != []
     assert results["docs_blob"]["collection_readme"]["name"] == "README.md"


### PR DESCRIPTION
This PR adds support for plugins with sidecar documentation.  Sidecar documentation is found in a `<stem>.yml` file located adjacent to the plugin file.

There are effectively 2 enumeration code paths in importer:

1. ansible-doc enumeration
2. filesystem walking for `.py` and `.ps1` files

The `ansible-doc` enumeration was effectively thrown away, and only used for extracting docs where a `.py` or `.ps1` file was found.

This combines the lists from both for full coverage since `ansible-doc` doesn't yet support enumerating extensions (such as eda), and the filesystem walking doesn't enumerate sidecar. I didn't extend the file system walking, as it could pick up unintended files, and ultimately we should move to only relying on ansible-doc enumeration once it supports extensions.

The test utilizing `community.general` is a good reproducer, as it contains sidecar documentation for `filter` plugins.  Another good test collection is `microsoft.ad` as it uses a lot of sidecar docs.