### PR TITLE
Add support for extracting docs from EDA plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,4 +35,4 @@ test/unit/annotate/clean:
 
 .PHONY: test/integration
 test/integration:
-	pytest tests/integration -v
+	pytest tests/integration -v --cov=galaxy_importer --cov-config=pyproject.toml --cov-report xml:coverage.xml --cov-append

--- a/galaxy_importer/collection.py
+++ b/galaxy_importer/collection.py
@@ -164,6 +164,13 @@ def _import_collection(file, filename, file_url, logger, cfg):
 
 def _extract_archive(fileobj, extract_dir):
     fileobj.seek(0)
+    _extract_kwargs = {}
+    if hasattr(tarfile, "data_filter"):
+        # Python added support for tarfile extraction filtering (PEP706) in
+        # response to CVE-2007-4559. This was introduced in Py3.12, although
+        # backported to other some earlier versions, and the default behavior
+        # will change in Python 3.14
+        _extract_kwargs["filter"] = "data"
     with tarfile.open(fileobj=fileobj, mode="r") as tf:
         for item in tf.getmembers():
             if item.name.startswith("/") or "../" in item.name:
@@ -175,4 +182,4 @@ def _extract_archive(fileobj, extract_dir):
                 )
                 if not link_target.startswith(os.path.abspath(extract_dir)):
                     raise exc.ImporterError("Invalid link target detected.")
-        tf.extractall(extract_dir)
+        tf.extractall(extract_dir, **_extract_kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,5 +99,5 @@ relative_files = true
 branch = true
 
 [tool.coverage.report]
-fail_under = 95.50
+fail_under = 90.00
 precision = 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,8 @@ extend-ignore = [
     # TD003 Missing issue link on the line following this TODO
     # We don't create issues for TODOs
     "TD003",
+    # SIM108 arguably creates less readable code
+    "SIM108",
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/tests/integration/test_eda.py
+++ b/tests/integration/test_eda.py
@@ -8,7 +8,7 @@ def test_eda_import(workdir, local_image_config):
     assert os.path.exists(workdir)
     url = (
         "https://beta-galaxy.ansible.com/api/v3/plugin/ansible/content/published/"
-        + "collections/artifacts/ansible-eda-1.4.2.tar.gz"
+        + "collections/artifacts/ansible-eda-2.6.0.tar.gz"
     )
     dst = os.path.join(workdir, os.path.basename(url))
     pid = subprocess.run(f"curl -L -o {dst} {url}", shell=True)
@@ -34,7 +34,7 @@ def test_eda_import(workdir, local_image_config):
     assert "EDA plugin content found. Running ruff on /extensions/eda/plugins..." in log
     # No errors in log to verify ruff ran
     assert "Running darglint on /extensions/eda/plugins..." in log
-    assert "aws_sqs_queue.py:main:33: DAR101" in log
+    assert "aws_sqs_queue.py:main:60: DAR101" in log
     assert "Running pylint on /extensions/eda/plugins/event_source..." in log
     assert "Running pylint on /extensions/eda/plugins/event_filter..." in log
     assert "EDA linting complete." in log
@@ -49,20 +49,206 @@ def test_eda_import(workdir, local_image_config):
         results = json.loads(f.read())
 
     # the data should have all the relevant bits
-    assert results["contents"] == [
-        {
-            "content_type": "module",
-            "description": "Upper cases a passed in string",
-            "name": "upcase",
-        },
-        {"content_type": "playbook", "description": None, "name": "hello.yml"},
-        {"content_type": "role", "description": "your role description", "name": "test_role"},
-    ]
+    results_contents = sorted(results["contents"], key=lambda c: (c["content_type"], c["name"]))
+    assert results_contents == sorted(
+        [
+            {"name": "hello.yml", "content_type": "playbook", "description": None},
+            {
+                "name": "credential_type_info",
+                "content_type": "module",
+                "description": "List credential types in EDA Controller",
+            },
+            {
+                "name": "user",
+                "content_type": "module",
+                "description": "Manage users in EDA controller",
+            },
+            {
+                "name": "rulebook_activation_info",
+                "content_type": "module",
+                "description": "List rulebook activations in the EDA Controller",
+            },
+            {
+                "name": "rulebook_info",
+                "content_type": "module",
+                "description": "List all rulebooks",
+            },
+            {
+                "name": "controller_token",
+                "content_type": "module",
+                "description": "Manage AWX tokens in EDA controller",
+            },
+            {
+                "name": "decision_environment",
+                "content_type": "module",
+                "description": "Create, update or delete decision environment in EDA Controller",
+            },
+            {
+                "name": "project_info",
+                "content_type": "module",
+                "description": "List projects in EDA Controller",
+            },
+            {
+                "name": "rulebook_activation",
+                "content_type": "module",
+                "description": "Manage rulebook activations in the EDA Controller",
+            },
+            {
+                "name": "credential_type",
+                "content_type": "module",
+                "description": "Manage credential types in EDA Controller",
+            },
+            {
+                "name": "event_stream",
+                "content_type": "module",
+                "description": "Manage event streams in EDA Controller",
+            },
+            {
+                "name": "event_stream_info",
+                "content_type": "module",
+                "description": "List event streams in the EDA Controller",
+            },
+            {
+                "name": "credential_info",
+                "content_type": "module",
+                "description": "List credentials in the EDA Controller",
+            },
+            {
+                "name": "credential",
+                "content_type": "module",
+                "description": "Manage credentials in EDA Controller",
+            },
+            {
+                "name": "decision_environment_info",
+                "content_type": "module",
+                "description": "List a decision environment in EDA Controller",
+            },
+            {
+                "name": "project",
+                "content_type": "module",
+                "description": "Create, update or delete project in EDA Controller",
+            },
+            {"name": "controller", "content_type": "module_utils", "description": None},
+            {"name": "arguments", "content_type": "module_utils", "description": None},
+            {"name": "client", "content_type": "module_utils", "description": None},
+            {"name": "common", "content_type": "module_utils", "description": None},
+            {"name": "errors", "content_type": "module_utils", "description": None},
+            {"name": "eda_controller", "content_type": "doc_fragments", "description": None},
+            {
+                "name": "insert_hosts_to_meta",
+                "content_type": "eda/plugins/event_filter",
+                "description": (
+                    "Extract hosts from the event data and insert them to the meta dict."
+                ),
+            },
+            {
+                "name": "dashes_to_underscores",
+                "content_type": "eda/plugins/event_filter",
+                "description": "Change dashes to underscores.",
+            },
+            {
+                "name": "normalize_keys",
+                "content_type": "eda/plugins/event_filter",
+                "description": (
+                    "Change keys that contain non-alpha numeric or underscore to underscores."
+                ),
+            },
+            {
+                "name": "noop",
+                "content_type": "eda/plugins/event_filter",
+                "description": "Do nothing.",
+            },
+            {
+                "name": "json_filter",
+                "content_type": "eda/plugins/event_filter",
+                "description": "Filter keys out of events.",
+            },
+            {
+                "name": "webhook",
+                "content_type": "eda/plugins/event_source",
+                "description": "Receive events via a webhook.",
+            },
+            {
+                "name": "alertmanager",
+                "content_type": "eda/plugins/event_source",
+                "description": (
+                    "Receive events via a webhook from alertmanager or a compatible alerting "
+                    "system."
+                ),
+            },
+            {
+                "name": "azure_service_bus",
+                "content_type": "eda/plugins/event_source",
+                "description": "Receive events from an Azure service bus.",
+            },
+            {
+                "name": "range",
+                "content_type": "eda/plugins/event_source",
+                "description": "Generate events with an increasing index i.",
+            },
+            {
+                "name": "generic",
+                "content_type": "eda/plugins/event_source",
+                "description": "A generic source plugin that allows you to insert custom data.",
+            },
+            {
+                "name": "url_check",
+                "content_type": "eda/plugins/event_source",
+                "description": "Poll a set of URLs and sends events with their status.",
+            },
+            {
+                "name": "aws_sqs_queue",
+                "content_type": "eda/plugins/event_source",
+                "description": "Receive events via an AWS SQS queue.",
+            },
+            {
+                "name": "file",
+                "content_type": "eda/plugins/event_source",
+                "description": "Load facts from YAML files initially and when the file changes.",
+            },
+            {
+                "name": "pg_listener",
+                "content_type": "eda/plugins/event_source",
+                "description": "Read events from pg_pub_sub.",
+            },
+            {
+                "name": "kafka",
+                "content_type": "eda/plugins/event_source",
+                "description": "Receive events via a kafka topic.",
+            },
+            {
+                "name": "journald",
+                "content_type": "eda/plugins/event_source",
+                "description": "Tail systemd journald logs.",
+            },
+            {
+                "name": "tick",
+                "content_type": "eda/plugins/event_source",
+                "description": "Generate events with an increasing index i that never ends.",
+            },
+            {
+                "name": "aws_cloudtrail",
+                "content_type": "eda/plugins/event_source",
+                "description": "Receive events from an AWS CloudTrail",
+            },
+            {
+                "name": "file_watch",
+                "content_type": "eda/plugins/event_source",
+                "description": "Watch file system changes.",
+            },
+        ],
+        key=lambda c: (c["content_type"], c["name"]),
+    )
     assert results["docs_blob"]["contents"] != []
+    eda_plugins = [
+        c for c in results["docs_blob"]["contents"] if c["content_type"].startswith("eda/")
+    ]
+    assert len(eda_plugins) == 19
+    assert eda_plugins[0]["doc_strings"] != {}
     assert results["docs_blob"]["collection_readme"]["name"] == "README.md"
     assert results["docs_blob"]["collection_readme"]["html"]
-    assert results["docs_blob"]["documentation_files"] == []
+    assert results["docs_blob"]["documentation_files"] != []
     assert results["metadata"]["namespace"] == "ansible"
     assert results["metadata"]["name"] == "eda"
-    assert results["metadata"]["version"] == "1.4.2"
-    assert results["requires_ansible"] == ">=2.9.10"
+    assert results["metadata"]["version"] == "2.6.0"
+    assert results["requires_ansible"] == ">=2.15.0"


### PR DESCRIPTION
This PR aims to add the capability to `galaxy-importer` to extract docs from collection extensions, specifically in this case EDA plugins.

As of now, `galaxy-importer` utilizes `ansible-doc` to enumerate plugins and extract their documentation.  As "collection extensions" are foreign to `ansible-core`, the `ansible-doc` utility does not currently contain the functionality to perform this duty.

In 50c83a132ccb56115e95e5c75fad03accac33533 functionality was added to `galaxy-importer` to enumerate the extenion plugins, but had no mechanism to load the documentation.  A documentation format used for all other ansible plugins has since been adopted for EDA, and `ansible-doc` can be "abused" by supplying a directory via `-M` to indicate another module directory to consider as modules, which enables extracting the docs. This has to be done on a plugin by plugin basis, as it also contains all other actual modules that are part of ansible-core.

The long term goal as implied above is for `ansible-doc` to support collection extensions, and once it does the `ExtensionLoader._get_plugin_doc_strings` can be removed. As of now it has been implemented to call `ansible-doc` for each plugin that is found, and return the docs.  The `PluginLoader._get_plugin_doc_strings` implementation should automatically support the functionality needed once `ansible-doc` can enumerate the extensions.

To test this change, the `ansible.eda` collection can be used. This is the same collection as used in `test/integration/test_eda.py`.  This PR also updates the collection to 2.6.0 which has adopted the proper documentation formats.