### PR TITLE
remove ecosystem-cert-preflight-checks task

### DIFF
--- a/.tekton/automation-hub-galaxy-importer-master-pull-request.yaml
+++ b/.tekton/automation-hub-galaxy-importer-master-pull-request.yaml
@@ -356,26 +356,6 @@ spec:
         operator: in
         values:
         - "false"
-    - name: ecosystem-cert-preflight-checks
-      params:
-      - name: image-url
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      runAfter:
-      - build-image-index
-      taskRef:
-        params:
-        - name: name
-          value: ecosystem-cert-preflight-checks
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:dea8d9b4bec3e99d612d799798acf132df48276164b5193ea68f9f3c25ae425b
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
     - name: sast-snyk-check
       params:
       - name: image-digest

--- a/.tekton/automation-hub-galaxy-importer-master-push.yaml
+++ b/.tekton/automation-hub-galaxy-importer-master-push.yaml
@@ -351,26 +351,6 @@ spec:
         operator: in
         values:
         - "false"
-    - name: ecosystem-cert-preflight-checks
-      params:
-      - name: image-url
-        value: $(tasks.build-image-index.results.IMAGE_URL)
-      runAfter:
-      - build-image-index
-      taskRef:
-        params:
-        - name: name
-          value: ecosystem-cert-preflight-checks
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:dea8d9b4bec3e99d612d799798acf132df48276164b5193ea68f9f3c25ae425b
-        - name: kind
-          value: task
-        resolver: bundles
-      when:
-      - input: $(params.skip-checks)
-        operator: in
-        values:
-        - "false"
     - name: sast-snyk-check
       params:
       - name: image-digest


### PR DESCRIPTION
The ecosystem-cert-preflight-checks task errors on the HasNoProhibitedPackages check which requires a base image that utilizes the RPM package manager, however galaxy-importer is based on Debian which utilizes the APT package manager.

According to https://github.com/release-engineering/rhtap-ec-policy/blob/main/data/required_tasks.yml the ecosystem-cert-preflight-checks task is not required.

Therefore, removing the ecosystem-cert-preflight-checks task will resolve the blocking enterprise contract errors in Konflux.