### PR TITLE
Update EDA tox linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ dist/
 
 # Environments
 .env
+.venv
+venv

--- a/galaxy_importer/ansible_test/container/eda/tox.ini
+++ b/galaxy_importer/ansible_test/container/eda/tox.ini
@@ -1,19 +1,12 @@
 [tox]
 requires = 
     ruff
-    darglint
     pylint
 
 
 [testenv:ruff]
 deps = ruff
-commands = - ruff check --select ALL --ignore INP001,FA102,UP001,UP010,I001,FA100,PLR0913,E501 -q {posargs}/extensions/eda/plugins
-
-
-[testenv:darglint]
-deps = darglint
-commands = - darglint -s numpy -z full {posargs}/extensions/eda/plugins
-
+commands = - ruff check --select ALL --ignore D100,D104,INP001,FA102,UP001,UP010,I001,FA100,PLR0913,E501 -q {posargs}/extensions/eda/plugins
 
 [testenv:pylint-event-source]
 deps = pylint

--- a/galaxy_importer/ansible_test/container/entrypoint.sh
+++ b/galaxy_importer/ansible_test/container/entrypoint.sh
@@ -73,9 +73,6 @@ then
     cd /eda/tox
     tox -q -e ruff -- $COLLECTION_DIR
 
-    echo "Running darglint on /extensions/eda/plugins..."
-    tox -q -e darglint -- $COLLECTION_DIR
-
     if [ -d "$EDA_PLUGIN_SOURCE" ]
     then
         echo "Running pylint on /extensions/eda/plugins/event_source..."

--- a/tests/integration/test_eda.py
+++ b/tests/integration/test_eda.py
@@ -35,8 +35,6 @@ def test_eda_import(workdir, local_image_config, capsys, monkeypatch):
     # EDA specific messages ...
     assert "EDA plugin content found. Running ruff on /extensions/eda/plugins..." in log
     # No errors in log to verify ruff ran
-    assert "Running darglint on /extensions/eda/plugins..." in log
-    assert "aws_sqs_queue.py:main:60: DAR101" in log
     assert "Running pylint on /extensions/eda/plugins/event_source..." in log
     assert "Running pylint on /extensions/eda/plugins/event_filter..." in log
     assert "EDA linting complete." in log


### PR DESCRIPTION
This is in efforts to remove discrepancies  between galaxy-importer and EDA collections and standardize what and how the tox checks are run in both places. This PR includes the following changes:

1. Remove `darglint` - we think this is redundant and having `ruff` would suffice. In addition, `darglint` is not part of EDA certified collection's [PR pipelines](https://github.com/ansible/event-driven-ansible/blob/a8b8972e102a9e047bc7f1d79becc4a4d7ca4cc5/.github/workflows/tox.yml#L48). 
2. Add 2 more error codes (D100, D104) to ruff ignore, as these are docstring related for the module files and it would be redundant since we already maintain one file for one module/plugin and have an in-file documentation for each. 

Misc: add `.venv` and `venv` to gitignore. 

EDA candidate PR for adding `ruff` check in github workflow of EDA collection: https://github.com/ansible/event-driven-ansible/pull/429

JIRA: [AAP-43843](https://issues.redhat.com/browse/AAP-43843)