### PR TITLE
Upgrade ansible-lint upper bound to 25.5.0

### DIFF
--- a/CHANGES/46637.feature
+++ b/CHANGES/46637.feature
@@ -1,0 +1,1 @@
+Upgraded the ansible-lint dependency upper bound from 25.1.2 to 25.5.x.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ``galaxy-importer`` requires the following other Ansible projects:
 
-* ``ansible-lint`` up to [25.1.2](https://github.com/ansible/ansible-lint/tree/v25.1.2/docs)
+* ``ansible-lint`` up to [25.5.x](https://github.com/ansible/ansible-lint/tree/v25.5.0/docs)
 * ``ansible-core`` up to [2.16](https://docs.ansible.com/ansible-core/2.16/index.html)
 
 If you are installing from source, see ``setup.cfg`` in the repository for the matching requirements.

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ packages = find:
 install_requires =
     ansible-core
     ansible-builder>=1.2.0,<4.0
-    ansible-lint>=6.2.2,<=25.1.2
+    ansible-lint>=6.2.2,<=25.5
     attrs>=21.4.0,<23
     nh3>=0.2.18,<3  # replaces bleach
     flake8>=5.0.0,<7


### PR DESCRIPTION
Upgrades the ansible-lint version to align with the upcoming downstream release (https://issues.redhat.com/browse/AAP-45488)

Issue: [AAP-46637](https://issues.redhat.com/browse/AAP-46637)