### PR TITLE
update konflux config to reflect new app name

### DIFF
--- a/.tekton/automation-hub-galaxy-importer-master-pull-request.yaml
+++ b/.tekton/automation-hub-galaxy-importer-master-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "master" && ( "galaxy_importer/ansible_test/container/***".pathChanged() || ".tekton/automation-hub-galaxy-importer-master-pull-request.yaml".pathChanged() )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: automation-hub-master
+    appstudio.openshift.io/application: automation-hub-main
     appstudio.openshift.io/component: automation-hub-galaxy-importer-master
     pipelines.appstudio.openshift.io/type: build
   name: automation-hub-galaxy-importer-master-on-pull-request
@@ -22,7 +22,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ansible-automationhu-tenant/automation-hub-master/automation-hub-galaxy-importer-master:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/ansible-automationhu-tenant/automation-hub-main/automation-hub-galaxy-importer-master:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: dockerfile

--- a/.tekton/automation-hub-galaxy-importer-master-push.yaml
+++ b/.tekton/automation-hub-galaxy-importer-master-push.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "master"
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: automation-hub-master
+    appstudio.openshift.io/application: automation-hub-main
     appstudio.openshift.io/component: automation-hub-galaxy-importer-master
     pipelines.appstudio.openshift.io/type: build
   name: automation-hub-galaxy-importer-master-on-push
@@ -21,7 +21,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ansible-automationhu-tenant/automation-hub-master/automation-hub-galaxy-importer-master:{{revision}}
+    value: quay.io/redhat-user-workloads/ansible-automationhu-tenant/automation-hub-main/automation-hub-galaxy-importer-master:{{revision}}
   - name: dockerfile
     value: Dockerfile
   - name: path-context


### PR DESCRIPTION
Updates the app name to reflect galaxy_ng's new branch name from `master` to `main`