### PR TITLE
removed unnecessary ansible-lint rules for testing certified content

### DIFF
--- a/galaxy_importer/loaders/collection.py
+++ b/galaxy_importer/loaders/collection.py
@@ -150,6 +150,8 @@ class CollectionLoader:
             "tests/unit/",
             "--parseable",
             "--nocolor",
+            "-x",
+            "yaml,var-naming,avoid-dot-notation,import-task-no-when,single-entry-point,use-loop",
         ]
         if self.cfg.offline_ansible_lint:
             cmd.append("--offline")


### PR DESCRIPTION
The Partner Engineering team has decided to exclude these tests from being ran on certified content.