### PR TITLE
Make patterns extraction warning

### DIFF
--- a/galaxy_importer/constants.py
+++ b/galaxy_importer/constants.py
@@ -61,6 +61,11 @@ META_PATTERN_DIR = "meta"
 
 MIN_ANSIBLE_LINT_PATTERNS_VERSION = "25.7.0"
 
+# Controls how galaxy-importer handles invalid patterns spec:
+# True -> Skip the patterns directory and log a warning, import continues.
+# False -> import fails.
+SKIP_PATTERNS_IMPORT_ON_ERROR = True
+
 # Content-Type
 PATTERNS_NAME = "patterns"
 

--- a/galaxy_importer/finder.py
+++ b/galaxy_importer/finder.py
@@ -254,7 +254,7 @@ class ContentFinder:
             for content_type, full_path in self._get_patterns_path():
                 yield content_type, full_path, patterns_finder.find_content
 
-        self.omit_patterns = patterns_finder.omit_patterns
+            self.omit_patterns = patterns_finder.omit_patterns
 
     def _get_ext_types_and_path(self):
         extension_dirs = ExtensionsFileParser(self.path).get_extension_dirs()

--- a/galaxy_importer/finder.py
+++ b/galaxy_importer/finder.py
@@ -25,6 +25,7 @@ import attr
 from galaxy_importer import constants
 from galaxy_importer.file_parser import ExtensionsFileParser, PatternsParser
 from galaxy_importer.exceptions import ContentFindError
+from galaxy_importer.utils.lint_version import is_lint_patterns_supported
 
 default_logger = logging.getLogger(__name__)
 
@@ -34,12 +35,6 @@ class Result(NamedTuple):
     path: str
 
 
-class PatternsFindError(ContentFindError):
-    def __init__(self, message="Default overwrite error occurred"):
-        self.message = message
-        super().__init__(self.message)
-
-
 ROLE_SUBDIRS = ["tasks", "vars", "handlers", "meta"]
 
 
@@ -47,8 +42,12 @@ ROLE_SUBDIRS = ["tasks", "vars", "handlers", "meta"]
 class PatternsFinder:
     path = attr.ib()
     log = attr.ib()
+    omit_patterns = attr.ib(default=False)
 
     def set_result(self, content_dir, content_type, file):
+        if file is None:
+            return
+
         file_path = os.path.join(content_dir, file)
         rel_path = self.get_rel_path(file_path)
         yield Result(content_type, rel_path)
@@ -70,6 +69,10 @@ class PatternsFinder:
             "pattern",
             allowed_extensions=[".json"],
         )
+
+        if pattern is None:
+            return
+
         yield from self.set_result(
             content_dir,
             constants.ContentType.PATTERNS,
@@ -81,12 +84,12 @@ class PatternsFinder:
 
         if not os.path.exists(playbooks_dir):
             rel_path = self.get_rel_path(content_dir)
-            raise ContentFindError(f"{rel_path} must contain playbooks directory")
+            self.warn_or_raise(f"{rel_path} must contain playbooks directory")
 
         playbooks = self._map_dir(playbooks_dir)
         if len(playbooks) < 1:
             rel_path = self.get_rel_path(playbooks_dir)
-            raise ContentFindError(f"{rel_path} must containt atleast one playbook")
+            self.warn_or_raise(f"{rel_path} must contain atleast one playbook")
 
         yield from self.set_results(playbooks_dir, constants.ContentType.PATTERNS, playbooks)
 
@@ -107,7 +110,9 @@ class PatternsFinder:
         req_file_exc_msg = f"{rel_path}({'/'.join(allowed_extensions)}) not found"
 
         if not os.path.exists(content_dir) and required:
-            raise ContentFindError(req_file_exc_msg)
+            self.warn_or_raise(req_file_exc_msg)
+            self.omit_patterns = True
+            return
         else:
             for content in os.listdir(content_dir):
                 if os.path.isfile(os.path.join(content_dir, content)):
@@ -120,7 +125,9 @@ class PatternsFinder:
                         return content
 
         if required:
-            raise ContentFindError(req_file_exc_msg)
+            self.warn_or_raise(req_file_exc_msg)
+            self.omit_patterns = True
+            return
 
     def _map_dir(self, content_dir):
         dirs = []
@@ -143,9 +150,17 @@ class PatternsFinder:
         # templates/
         yield from self.find_templates(content_dir)
 
+    def warn_or_raise(self, message):
+        if constants.SKIP_PATTERNS_IMPORT_ON_ERROR:
+            self.log.warning(message)
+        else:
+            raise ContentFindError(message)
+
 
 class ContentFinder:
     """Searches for content in directories inside collection."""
+
+    omit_patterns = False
 
     def find_contents(self, path, logger=None):
         """Finds contents in path and return the results.
@@ -234,9 +249,12 @@ class ContentFinder:
         for content_type, full_path in self._get_ext_types_and_path():
             yield content_type, full_path, self._find_plugins
 
-        patterns_finder = PatternsFinder(self.path, self.log)
-        for content_type, full_path in self._get_patterns_path():
-            yield content_type, full_path, patterns_finder.find_content
+        if is_lint_patterns_supported():
+            patterns_finder = PatternsFinder(self.path, self.log)
+            for content_type, full_path in self._get_patterns_path():
+                yield content_type, full_path, patterns_finder.find_content
+
+        self.omit_patterns = patterns_finder.omit_patterns
 
     def _get_ext_types_and_path(self):
         extension_dirs = ExtensionsFileParser(self.path).get_extension_dirs()

--- a/galaxy_importer/utils/lint_version.py
+++ b/galaxy_importer/utils/lint_version.py
@@ -1,4 +1,6 @@
 from importlib.metadata import version, PackageNotFoundError
+from packaging.version import Version
+from galaxy_importer import constants
 
 
 def get_version_from_metadata(package_name):
@@ -7,3 +9,14 @@ def get_version_from_metadata(package_name):
         return version(package_name)
     except PackageNotFoundError:
         return ""
+
+
+def is_lint_patterns_supported():
+    """
+    minimum ansible-lint version that supports patterns validating is >=25.7.0.
+    importer must skip loading/parsing patterns directory if ansible-lint
+    version doesn't support patterns.
+    """
+    return Version(get_version_from_metadata("ansible-lint")) >= Version(
+        constants.MIN_ANSIBLE_LINT_PATTERNS_VERSION
+    )

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ dev =
     pytest-cov>=3.0.0,<5
     pytest_mock>=3.8.0,<4
     towncrier
-    ruff
+    ruff>=0.12,<0.13
 
 [options.package_data]
 galaxy_importer =

--- a/tests/unit/test_lint_version_utils.py
+++ b/tests/unit/test_lint_version_utils.py
@@ -1,0 +1,18 @@
+import pytest
+from unittest.mock import patch
+
+from galaxy_importer.utils.lint_version import is_lint_patterns_supported
+
+
+@patch("galaxy_importer.utils.lint_version.get_version_from_metadata")
+@pytest.mark.parametrize(
+    ("lint_version", "enabled"),
+    [
+        ("25.6.9", False),
+        ("25.7.0", True),
+        ("25.8.0", True),
+    ],
+)
+def test_is_lint_patterns_supported(mock_lint_version, lint_version, enabled):
+    mock_lint_version.return_value = lint_version
+    assert is_lint_patterns_supported() is enabled

--- a/tests/unit/test_loader_collection.py
+++ b/tests/unit/test_loader_collection.py
@@ -811,6 +811,7 @@ def test_lint_meta_patterns(
     logs = " ".join([r.message for r in caplog.records])
     assert message in logs
 
+
 @pytest.mark.skipif(
     Version(MIN_ANSIBLE_LINT_PATTERNS_VERSION) > Version(get_version_from_metadata("ansible-lint")),
     reason="Requires ansible-lint>=25.7.0",

--- a/tests/unit/test_loader_collection.py
+++ b/tests/unit/test_loader_collection.py
@@ -810,3 +810,23 @@ def test_lint_meta_patterns(
 
     logs = " ".join([r.message for r in caplog.records])
     assert message in logs
+
+
+def test_omitting_patterns_message(tmp_collection_root, populated_collection_root, caplog):
+    os.makedirs(os.path.join(tmp_collection_root, "extensions", "patterns", "foo_bar", "meta"))
+
+    collection_loader = CollectionLoader(
+        populated_collection_root,
+        filename=None,
+        cfg=SimpleNamespace(
+            run_ansible_doc=False,
+            run_ansible_lint=False,
+            offline_ansible_lint=False,
+            ansible_local_tmp=tmp_collection_root,
+        ),
+    )
+    collection_loader.doc_strings = {}
+    list(collection_loader._load_contents())
+
+    logs = " ".join([f"{r.levelname}: {r.message}" for r in caplog.records])
+    assert "WARNING: Extracting patterns failed, skipping patterns directory loading" in logs

--- a/tests/unit/test_loader_collection.py
+++ b/tests/unit/test_loader_collection.py
@@ -811,7 +811,10 @@ def test_lint_meta_patterns(
     logs = " ".join([r.message for r in caplog.records])
     assert message in logs
 
-
+@pytest.mark.skipif(
+    Version(MIN_ANSIBLE_LINT_PATTERNS_VERSION) > Version(get_version_from_metadata("ansible-lint")),
+    reason="Requires ansible-lint>=25.7.0",
+)
 def test_omitting_patterns_message(tmp_collection_root, populated_collection_root, caplog):
     os.makedirs(os.path.join(tmp_collection_root, "extensions", "patterns", "foo_bar", "meta"))
 


### PR DESCRIPTION
Issue: [AAP-53303](https://issues.redhat.com/browse/AAP-53303)

This fixes the importer that patterns errors are logged as warnings instead of stopping the importer.

Some existing collections, such as [infra.windows_ops v1.0.2 ](https://console.redhat.com/ansible/automation-hub/repo/validated/infra/windows_ops/)has incorrect (obsolete?) patterns scheme. With recent https://github.com/ansible/galaxy-importer/pull/356, it's not possible to upload that collection anymore and that's currently breaking the bundled installer.

