### PR TITLE
Upgrade ansible-lint upper bound to 25.9.1

### DIFF
--- a/CHANGES/53637.feature
+++ b/CHANGES/53637.feature
@@ -1,0 +1,1 @@
+Upgrade the ansible-lint dependency bound from 25.8.2 to 25.9.1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ``galaxy-importer`` requires the following other Ansible projects:
 
-* ``ansible-lint`` up to [25.8.2](https://github.com/ansible/ansible-lint/tree/v25.8.2/docs)
+* ``ansible-lint`` up to [25.9.x](https://github.com/ansible/ansible-lint)
 * ``ansible-core`` up to [2.16](https://docs.ansible.com/ansible-core/2.16/index.html)
 
 If you are installing from source, see ``setup.cfg`` in the repository for the matching requirements.

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ packages = find:
 install_requires =
     ansible-core
     ansible-builder>=1.2.0,<4.0
-    ansible-lint>=6.2.2,<=25.8.2
+    ansible-lint>=6.2.2,<=25.9.1
     attrs>=21.4.0,<23
     nh3>=0.2.18,<3  # replaces bleach
     flake8>=5.0.0,<7


### PR DESCRIPTION
Upgrades the ansible-lint upper bound to 25.9.1. Since ansible-lint 25.9.0 will be released soon, this allows for another patch release in September if needed.