### PR TITLE
Fix latest ruff 0.13 rules

### DIFF
--- a/galaxy_importer/ansible_test/builders/local_image_build.py
+++ b/galaxy_importer/ansible_test/builders/local_image_build.py
@@ -93,7 +93,6 @@ class Build:
 
     @staticmethod
     def _build_image_with_artifact(container_engine, dirname):
-
         with resource_filename_compat(
             "galaxy_importer", "ansible_test/container/entrypoint.sh"
         ) as pkg_entrypoint:

--- a/galaxy_importer/ansible_test/runners/local_ansible_test.py
+++ b/galaxy_importer/ansible_test/runners/local_ansible_test.py
@@ -65,7 +65,7 @@ class LocalAnsibleTestRunner(BaseTestRunner):
 
         collection_name = f"{self.metadata.namespace}-{self.metadata.name}-{self.metadata.version}"
         self.log.info(f"Running ansible-test sanity on {collection_name} ...")
-        self.log.info(f'{" ".join(cmd)}')
+        self.log.info(f"{' '.join(cmd)}")
 
         proc = subprocess.Popen(
             cmd,

--- a/galaxy_importer/file_parser.py
+++ b/galaxy_importer/file_parser.py
@@ -47,8 +47,7 @@ class RuntimeFileParser:
     def get_requires_ansible(self):
         if not self.data:
             raise exc.FileParserError(
-                "'requires_ansible' in meta/runtime.yml is mandatory, "
-                "but no meta/runtime.yml found"
+                "'requires_ansible' in meta/runtime.yml is mandatory, but no meta/runtime.yml found"
             )
         requires_ansible = self.data.get("requires_ansible")
         if not requires_ansible:

--- a/galaxy_importer/schema.py
+++ b/galaxy_importer/schema.py
@@ -239,7 +239,7 @@ class CollectionInfo:
         - tag regular expression
         - tag max length
         """
-        no_req_tag_err = f'At least one tag required from tag list: {", ".join(REQUIRED_TAG_LIST)}'
+        no_req_tag_err = f"At least one tag required from tag list: {', '.join(REQUIRED_TAG_LIST)}"
 
         config_data = config.ConfigFile.load()
         cfg = config.Config(config_data=config_data)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,10 +64,6 @@ extend-ignore = [
     # UP032 Use f-string instead of `format` call.
     # No need to replace all str.format usage with f-strings in entire codebase.
     "UP032",
-    # PT004,PT005 are incorrect and deprecated
-    # See https://github.com/astral-sh/ruff/issues/8796
-    "PT004",
-    "PT005",
     # PT009 Use a regular `assert` instead of unittest-style
     # PT027 Use `pytest.raises` instead of unittest-style `assertRaises`
     # Ignoring, since we have mixed pytest and legacy unittest styled tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ dev =
     pytest-cov>=3.0.0,<5
     pytest_mock>=3.8.0,<4
     towncrier
-    ruff>=0.12,<0.13
+    ruff
 
 [options.package_data]
 galaxy_importer =

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -66,7 +66,7 @@ def test_config_set_from_file(temp_config_file):
 
 def test_config_set_from_env(temp_config_file_b, monkeypatch):
     with open(temp_config_file_b, "w") as f:
-        f.write("[galaxy-importer]\nRUN_ANSIBLE_TEST = True\n" "INFRA_PULP = True")
+        f.write("[galaxy-importer]\nRUN_ANSIBLE_TEST = True\nINFRA_PULP = True")
         f.flush()
         monkeypatch.setenv("GALAXY_IMPORTER_CONFIG", temp_config_file_b)
         config_data = config.ConfigFile.load()
@@ -106,7 +106,7 @@ def test_config_bad_ini_section(temp_config_file):
 
 def test_config_with_non_boolean(temp_config_file):
     with open(temp_config_file, "w") as f:
-        f.write("[galaxy-importer]\nRUN_ANSIBLE_TEST = True\n" "LOG_LEVEL_MAIN = DEBUG")
+        f.write("[galaxy-importer]\nRUN_ANSIBLE_TEST = True\nLOG_LEVEL_MAIN = DEBUG")
         f.flush()
         config_data = config.ConfigFile.load()
         cfg = config.Config(config_data=config_data)

--- a/tests/unit/test_file_parser.py
+++ b/tests/unit/test_file_parser.py
@@ -20,6 +20,7 @@ import pytest
 import tempfile
 import shutil
 import json
+import re
 
 from galaxy_importer import exceptions as exc
 from galaxy_importer import file_parser
@@ -86,7 +87,7 @@ def test_no_runtime_file(tmpdir):
 
 def test_runtime_file_bad_yaml(tmpdir):
     tmpdir.mkdir("meta").join("runtime.yml").write(BAD_YAML)
-    with pytest.raises(exc.FileParserError, match="Error during parsing of runtime.yml"):
+    with pytest.raises(exc.FileParserError, match=re.escape("Error during parsing of runtime.yml")):
         file_parser.RuntimeFileParser(collection_path=tmpdir)
 
 
@@ -138,7 +139,9 @@ def test_bad_version_spec(tmpdir):
 
 def test_extensions_file_bad_yaml(tmpdir):
     tmpdir.mkdir("meta").join("extensions.yml").write(BAD_YAML)
-    with pytest.raises(exc.FileParserError, match="Error during parsing of extensions.yml"):
+    with pytest.raises(
+        exc.FileParserError, match=re.escape("Error during parsing of extensions.yml")
+    ):
         file_parser.ExtensionsFileParser(collection_path=tmpdir)
 
 
@@ -160,7 +163,7 @@ def test_extensions_file_missing_keys(tmpdir, extensions_yaml):
     tmpdir.mkdir("meta").join("extensions.yml").write(extensions_yaml)
     parser = file_parser.ExtensionsFileParser(collection_path=tmpdir)
     with pytest.raises(
-        exc.FileParserError, match="meta/extensions.yml is not in the expected format"
+        exc.FileParserError, match=re.escape("meta/extensions.yml is not in the expected format")
     ):
         parser.get_extension_dirs()
 
@@ -235,7 +238,9 @@ class TestPatternsParser:
         patterns_parser = file_parser.PatternsParser(self.collection_path)
         with pytest.raises(
             exc.FileParserError,
-            match="Error during parsing of extensions/patterns/foo.bar/meta/pattern.json",
+            match=re.escape(
+                "Error during parsing of extensions/patterns/foo.bar/meta/pattern.json"
+            ),
         ):
             patterns_parser._load_meta_pattern("foo.bar")
 

--- a/tests/unit/test_finder.py
+++ b/tests/unit/test_finder.py
@@ -179,7 +179,6 @@ class TestContentFinder(unittest.TestCase):
         assert len(contents) == 0
 
     def test_find_playbooks(self):
-
         content = [
             {
                 "name": "a test playbook",

--- a/tests/unit/test_import_collection.py
+++ b/tests/unit/test_import_collection.py
@@ -55,7 +55,7 @@ def test_import_collection(mocker):
 def test_sync_collection(tmp_collection_root):
     git_url = "https://github.com/openshift/community.okd.git"
     Repo.clone_from(git_url, tmp_collection_root, depth=1)
-    metadata, filepath = collection.sync_collection(tmp_collection_root, tmp_collection_root)
+    _metadata, filepath = collection.sync_collection(tmp_collection_root, tmp_collection_root)
     assert "community-okd" in filepath
 
 
@@ -84,7 +84,7 @@ def test__build_collection(tmp_collection_root):
     filepath = collection._build_collection(tmp_collection_root, tmp_collection_root)
     assert "community-okd" in filepath
 
-    with pytest.raises(exc.ImporterError, match="file .+ already exists"):
+    with pytest.raises(exc.ImporterError, match=r"file .+ already exists"):
         collection._build_collection(tmp_collection_root, tmp_collection_root)
 
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -16,6 +16,7 @@
 # along with Galaxy.  If not, see <http://www.apache.org/licenses/>.
 
 import pytest
+import re
 
 from galaxy_importer import main
 
@@ -40,7 +41,9 @@ def test_parser():
 
 
 def test_main_no_args():
-    with pytest.raises(TypeError, match="expected str, bytes or os.PathLike object, not NoneType"):
+    with pytest.raises(
+        TypeError, match=re.escape("expected str, bytes or os.PathLike object, not NoneType")
+    ):
         main.main(args={})
 
 

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -54,7 +54,7 @@ def test_get_runner_ansible_test_local(temp_config_file):
 
 def test_get_runner_local_image(temp_config_file):
     with open(temp_config_file, "w") as f:
-        f.write("[galaxy-importer]\nRUN_ANSIBLE_TEST = True\n" "ANSIBLE_TEST_LOCAL_IMAGE = True")
+        f.write("[galaxy-importer]\nRUN_ANSIBLE_TEST = True\nANSIBLE_TEST_LOCAL_IMAGE = True")
         f.flush()
         config_data = config.ConfigFile.load()
         cfg = config.Config(config_data=config_data)

--- a/tests/unit/test_schema_legacy.py
+++ b/tests/unit/test_schema_legacy.py
@@ -185,7 +185,7 @@ def test_valid_dependencies(galaxy_info, valid_dependency):
 def test_invalid_dependency_type(galaxy_info, invalid_dependency):
     with pytest.raises(
         exc.LegacyRoleSchemaError,
-        match="must be either a list of strings or a list of dictionaries.",
+        match=re.escape("must be either a list of strings or a list of dictionaries."),
     ):
         LegacyMetadata(LegacyGalaxyInfo(**galaxy_info), invalid_dependency)
 
@@ -206,7 +206,7 @@ def test_invalid_dependency_type(galaxy_info, invalid_dependency):
 def test_invalid_dependency_dict_type(galaxy_info, invalid_dict):
     with pytest.raises(
         exc.LegacyRoleSchemaError,
-        match="dependency must include either the 'role,' 'name,' or 'src' keyword.",
+        match=re.escape("dependency must include either the 'role,' 'name,' or 'src' keyword."),
     ):
         LegacyMetadata(LegacyGalaxyInfo(**galaxy_info), invalid_dict)
 
@@ -237,7 +237,9 @@ def test_valid_dependency_types(galaxy_info, dependencies):
 def test_invalid_dependency_separation(galaxy_info):
     dependencies = ["foo.bar.baz"]
 
-    with pytest.raises(exc.LegacyRoleSchemaError, match="namespace and name separated by '.'"):
+    with pytest.raises(
+        exc.LegacyRoleSchemaError, match=re.escape("namespace and name separated by '.'")
+    ):
         LegacyMetadata(LegacyGalaxyInfo(**galaxy_info), dependencies)
 
 


### PR DESCRIPTION
No-Issue

Incorporate rules from latest [0.13 ruff](https://github.com/astral-sh/ruff/releases/tag/0.13.0)

Fixed rules:
- RUF043 Pattern passed to `match=` contains metacharacters but is neither escaped nor raw
- RUF059 Unpacked variable `metadata` is never used

Removed deprecated ignored PT004, PT005 rules:
```
warning: The following rules have been removed and ignoring them has no effect:
    - PT004
    - PT005
```

CI logs with issues: https://github.com/ansible/galaxy-importer/actions/runs/17622185306/job/50070231444
