### PR TITLE
Upgrade ansible-lint upper bound to 26.4.0

### DIFF
--- a/CHANGES/lint-26-4-0.feature
+++ b/CHANGES/lint-26-4-0.feature
@@ -1,1 +1,1 @@
-Upgrade the ansible-lint dependency bound from 25.12.0 to 26.4.0.
+Upgrade the ansible-lint dependency bound from 26.1.0 to 26.4.0.

--- a/CHANGES/lint-26-4-0.feature
+++ b/CHANGES/lint-26-4-0.feature
@@ -1,0 +1,1 @@
+Upgrade the ansible-lint dependency bound from 25.12.0 to 26.4.0.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ``galaxy-importer`` requires the following other Ansible projects:
 
-* ``ansible-lint`` up to [26.1.0](https://github.com/ansible/ansible-lint/tree/v26.1.0)
+* ``ansible-lint`` up to [26.4.0](https://github.com/ansible/ansible-lint/tree/v26.4.0)
 * ``ansible-core`` up to [2.16](https://docs.ansible.com/ansible-core/2.16/index.html)
 
 If you are installing from source, see ``setup.cfg`` in the repository for the matching requirements.

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ packages = find:
 install_requires =
     ansible-core
     ansible-builder>=1.2.0,<4.0
-    ansible-lint>=6.2.2,<=26.1.0
+    ansible-lint>=6.2.2,<=26.4.0
     attrs>=21.4.0,<23
     nh3>=0.2.18,<3  # replaces bleach
     flake8>=5.0.0,<7


### PR DESCRIPTION
Upgrades the ansible-lint bound in preparation for the upcoming AAP 2.7 release.