### PR TITLE
Fix ReDoS vulnerabilities in name validation regexes

### DIFF
--- a/galaxy_importer/constants.py
+++ b/galaxy_importer/constants.py
@@ -37,14 +37,14 @@ ANSIBLE_DOC_SUPPORTED_TYPES = [
 ANSIBLE_DOC_PLUGIN_MAP = {"module": "modules"}
 ANSIBLE_DOC_KEYS = ["doc", "metadata", "examples", "return"]
 ANSIBLE_LINT_ERROR_PREFIXES = ("CRITICAL", "ERROR")
-CONTENT_NAME_REGEXP = re.compile(r"^(?!.*__)[a-z_]+[0-9a-z_]*$")
+CONTENT_NAME_REGEXP = re.compile(r"^(?!.*__)[a-z_][0-9a-z_]*$")
 ROLE_META_FILES = ["meta/main.yml", "meta/main.yaml", "meta.yml", "meta.yaml"]
 FLAKE8_MAX_LINE_LENGTH = 160
 FLAKE8_IGNORE_ERRORS = "E402"
 FLAKE8_SELECT_ERRORS = "E,F,W"
 MAX_LENGTH_REQUIRES_ANSIBLE = 255
 MAX_TAGS_COUNT = 20
-NAME_REGEXP = re.compile(r"^(?!.*__)[a-z]+[0-9a-z_]*$")
+NAME_REGEXP = re.compile(r"^(?!.*__)[a-z][0-9a-z_]*$")
 
 # For these extensions we support listing them in the galaxy contents list
 # In the future we may allow any extension to be listed, and call ansible-doc on it
@@ -86,7 +86,7 @@ LEGACY_ROLE_NAME_REGEXP = re.compile("^[a-zA-Z0-9_-]{1,55}$")
 # Maximum of 39 char tested in the validator
 # For retrocompatibility with legacy role, allow names
 # finishing with hyphen or underscores, and names containing dots
-LEGACY_NAMESPACE_REGEXP = re.compile("^([a-zA-Z0-9.]+[-_]?)+$")
+LEGACY_NAMESPACE_REGEXP = re.compile("^[a-zA-Z0-9.]+(?:[-_][a-zA-Z0-9.]+)*[-_]?$")
 
 
 class ContentCategory(str, enum.Enum):


### PR DESCRIPTION
## Summary

- Fix polynomial backtracking (ReDoS) in `CONTENT_NAME_REGEXP` and `NAME_REGEXP` by removing redundant `+` quantifiers on first character classes that overlap with the following group
- Fix exponential backtracking (ReDoS) in `LEGACY_NAMESPACE_REGEXP` by flattening nested quantifiers into a linear-time equivalent pattern
- All three fixes are semantically identical to the original regexes (verified exhaustively against hundreds of thousands of test strings)

Resolves [AAP-71476](https://redhat.atlassian.net/browse/AAP-71476)

## Test plan

- [x] All existing unit tests pass (140 passed, 3 xfailed)
- [x] `CONTENT_NAME_REGEXP`: exhaustively verified 41,371 strings — zero behavioral differences
- [x] `NAME_REGEXP`: exhaustively verified 41,371 strings — zero behavioral differences
- [x] `LEGACY_NAMESPACE_REGEXP`: exhaustively verified 597,871 strings — zero behavioral differences
- [x] Performance: 10,000-char adversarial inputs complete in <1ms (previously would hang)

🤖 Generated with [Claude Code](https://claude.com/claude-code)