### PR TITLE
Add CPE label to fix konflux ec errors

### DIFF
--- a/galaxy_importer/ansible_test/container/Dockerfile
+++ b/galaxy_importer/ansible_test/container/Dockerfile
@@ -10,7 +10,8 @@ LABEL   com.redhat.component="ansible-test" \
         summary="Container used by galaxy for running ansible-test validation." \
         url="https://github.com/ansible/galaxy-importer" \
         vendor="Red Hat, Inc." \
-        version="0.4.26"
+        version="0.4.26" \
+        cpe="cpe:/a:redhat:galaxy-importer:0.4::appstream"
 
 COPY entrypoint.sh /entrypoint
 


### PR DESCRIPTION
Effective June 6 2026, a CPE label is required on product images built in Konflux.

This PR adds the CPE label indicating the galaxy-importer product and version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image metadata to enhance security compliance and tracking capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->