### PR TITLE
Bump pip and base-test-container in ansible-test container

### DIFF
--- a/galaxy_importer/ansible_test/container/Dockerfile
+++ b/galaxy_importer/ansible_test/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ansible/base-test-container:6.1.0
+FROM quay.io/ansible/base-test-container:6.2.0
 
 LABEL   com.redhat.component="ansible-test" \
         description="Container used by galaxy for running ansible-test validation." \
@@ -29,6 +29,7 @@ RUN useradd user1 \
     mkdir -m 0775 /archive && \
     mkdir -p -m 0775 /ansible_collections /ansible_collections/ns /ansible_collections/ns/col && \
     touch /ansible_collections/ns/col/placeholder.txt && \
+    python3.11 -m pip install "pip>=26.1.2" --disable-pip-version-check && \
     # On updating ansible-core version, update the FROM statement to the matching base-test-container version
     python3.11 -m pip install ansible-core==2.16.0 --disable-pip-version-check && \
     python3.11 -m pip install "cryptography>=46.0.7" --disable-pip-version-check && \


### PR DESCRIPTION
## Summary
- Bump `base-test-container` from 6.1.0 to 6.2.0
- Pin `pip>=26.1.2` as the first pip install in the Dockerfile to ensure an up-to-date pip is used for all subsequent package installs

## Test plan
- [x] Container build passes locally with both changes

Issue: AAP-76339

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base test container image to a newer version.
  * Updated Python package manager to a minimum version for Python 3.11 before installing dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->