### PR TITLE
feat: add CodeCov integration for coverage tracking

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: matrix.python-version == '3.11'
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
       with:
         files: ./coverage.xml
         flags: unit-tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,14 @@ jobs:
         name: coverage
         path: coverage.xml
 
+    - name: Upload coverage to Codecov
+      if: matrix.python-version == '3.11'
+      uses: codecov/codecov-action@v4
+      with:
+        files: ./coverage.xml
+        flags: unit-tests
+        fail_ci_if_error: false
+
     - name: SonarCloud Scan
       uses: SonarSource/sonarqube-scan-action@v6
       if: github.event_name == 'push' && github.repository == 'ansible/galaxy-importer' && github.ref_name == 'master' && matrix.python-version == '3.11'

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  ignore:
+    - "tests/**"
+    - "**/*.test.py"
+    - "**/*.spec.py"
+    - "**/test_*.py"
+    - "setup.py"
+    - "build_deploy.sh"

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,4 +5,3 @@ coverage:
     - "**/*.spec.py"
     - "**/test_*.py"
     - "setup.py"
-    - "build_deploy.sh"


### PR DESCRIPTION
- Add CodeCov upload step to CI workflow after coverage generation
- Create codecov.yml with standard Python exclusions
- Upload runs on Python 3.11 matrix job only
- Tagged with unit-tests flag for tracking

Part of CoverPort onboarding initiative to track code coverage as a leading quality indicator.

Related: AAP-74923

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled conditional automated Codecov coverage upload during CI for the designated test matrix entry.
  * Updated Codecov configuration to ignore coverage for test files and common test/setup patterns.
  * Prevented CI failures if the coverage upload encounters errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->