### PR TITLE
Allow attrs < 24

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ install_requires =
     ansible-core
     ansible-builder>=1.2.0,<4.0
     ansible-lint>=6.2.2,<=26.6.0
-    attrs>=21.4.0,<23
+    attrs>=21.4.0,<24
     nh3>=0.3.6,<4  # replaces bleach
     flake8>=5.0.0,<7
     markdown>=3.3.4,<4


### PR DESCRIPTION
EL10 now ships python3-attrs-23.2.0-7.el10 in the platform python, any installation with RPMs breaks now.

We caught that at https://github.com/theforeman/el10_rebuild/issues/26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the supported `attrs` dependency range to allow version 23 releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->