### PR TITLE
fix(deps): bump ansible-lint upper bound to <=26.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ``galaxy-importer`` requires the following other Ansible projects:
 
-* ``ansible-lint`` up to [26.6.0](https://github.com/ansible/ansible-lint/tree/v26.6.0)
+* ``ansible-lint`` up to [26.8.0](https://github.com/ansible/ansible-lint/tree/v26.8.0)
 * ``ansible-core`` up to [2.16](https://docs.ansible.com/ansible-core/2.16/index.html)
 
 If you are installing from source, see ``setup.cfg`` in the repository for the matching requirements.

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ packages = find:
 install_requires =
     ansible-core
     ansible-builder>=1.2.0,<4.0
-    ansible-lint>=6.2.2,<=26.6.0
+    ansible-lint>=6.2.2,<=26.8.0
     attrs>=21.4.0,<24
     nh3>=0.3.6,<4  # replaces bleach
     flake8>=5.0.0,<7


### PR DESCRIPTION
## Summary
- Bump ansible-lint upper bound from <=26.6.0 to <=26.8.0
- ansible-lint 26.8.0 released upstream, this unblocks downstream RPM builds

Assisted-by: Claude-code