### PR TITLE
Bump ansible-core to 2.16.19 in ansible-test container

### DIFF
--- a/galaxy_importer/ansible_test/container/Dockerfile
+++ b/galaxy_importer/ansible_test/container/Dockerfile
@@ -32,7 +32,7 @@ RUN useradd user1 \
     touch /ansible_collections/ns/col/placeholder.txt && \
     python3.11 -m pip install "pip>=26.1.2" --disable-pip-version-check && \
     # On updating ansible-core version, update the FROM statement to the matching base-test-container version
-    python3.11 -m pip install ansible-core==2.16.0 --disable-pip-version-check && \
+    python3.11 -m pip install ansible-core==2.16.19 --disable-pip-version-check && \
     python3.11 -m pip install "cryptography>=46.0.7" --disable-pip-version-check && \
     python3.11 -m pip install tox && \
     python3.11 -m pip install --upgrade setuptools && \


### PR DESCRIPTION
## Summary
- Bump `ansible-core` to `2.16.19` in the ansible-test container Dockerfile

## Test plan
- [x] Container build passes locally

Issue: [AAP-84177](https://redhat.atlassian.net/browse/AAP-84177)

[AAP-84177]: https://redhat.atlassian.net/browse/AAP-84177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the container’s Ansible Core version to 2.16.19 for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->